### PR TITLE
Widen clipboard restore delay to prevent stale paste

### DIFF
--- a/swift/Sources/Presspeech/main.swift
+++ b/swift/Sources/Presspeech/main.swift
@@ -50,7 +50,7 @@ let MAX_RECORDING_SECONDS: TimeInterval = 120   // auto-release if held longer
 // pasteboard before we write the old contents back over it. Quartz has
 // no paste-consumed acknowledgement, which is why restoration remains
 // an opt-in, best-effort behavior.
-let CLIPBOARD_RESTORE_DELAY_SECONDS: TimeInterval = 0.15
+let CLIPBOARD_RESTORE_DELAY_SECONDS: TimeInterval = 0.4
 let UPDATE_CHECK_FIRST_DELAY_SECONDS: TimeInterval = 30
 let UPDATE_CHECK_INTERVAL_SECONDS: TimeInterval = 6 * 3600  // 6h
 let UPDATE_REMIND_LATER_SECONDS: TimeInterval = 24 * 3600  // 24h


### PR DESCRIPTION
## Summary

Dictation with **Restore clipboard after paste** enabled sometimes pasted the *previous* clipboard contents instead of the transcript.

The restore is scheduled `CLIPBOARD_RESTORE_DELAY_SECONDS` after posting the synthetic `Cmd+V`. The paste event is delivered asynchronously and Quartz gives no paste-consumed acknowledgement, so on some setups the 0.15s delay fired *before* the focused app read the transcript off the pasteboard — the old contents were written back first and got pasted instead.

This widens the delay from **0.15s to 0.4s**, leaving a safer margin for the paste to complete before the previous clipboard is restored. The `changeCount` guard around the restore is unchanged, so a fresh copy made in the meantime is still never clobbered.

## Changes

- `swift/Sources/Presspeech/main.swift`: `CLIPBOARD_RESTORE_DELAY_SECONDS` `0.15` → `0.4` (single-line change).

## Testing

- `swift build` — clean.
- `swift run Presspeech --self-test all` — `PASS all`.
- Manual: dictated into a text field with a link on the clipboard; the transcript is pasted and the link is restored afterwards.