### PR TITLE
Add Windows push-to-talk app

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,35 @@
+name: windows
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "windows/**"
+      - ".github/workflows/windows.yml"
+  pull_request:
+    paths:
+      - "windows/**"
+      - ".github/workflows/windows.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: windows/requirements.txt
+      - name: Install dependencies
+        working-directory: windows
+        run: python -m pip install -r requirements.txt
+      - name: Unit tests
+        working-directory: windows
+        run: python -m unittest discover -s tests -v
+      - name: Compile Python sources
+        working-directory: windows
+        run: python -m compileall -q app.py benchmark.py british.py config.py engine.py ui.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,9 @@ Briefing for AI coding agents working on this repo. Complements
 
 ## Project shape
 
-Presspeech is a **single-file Swift menu-bar app** for push-to-talk
-dictation on Apple Silicon Macs. The whole app is
+Presspeech has isolated macOS and Windows implementations. The released macOS
+app is a **single-file Swift menu-bar app** for push-to-talk dictation on Apple
+Silicon Macs. The whole macOS app is
 `swift/Sources/Presspeech/main.swift` (currently about 12k lines). The `PresspeechApp`
 @MainActor class owns the menu bar, settings UI, recording loop,
 and update flow; surrounding it in the same file are the
@@ -43,6 +44,7 @@ single-responsibility types it composes (`Settings`, `Permissions`,
 | `scripts/update-model-manifest.py` | Regenerates the pinned SHA-256 manifest for the Parakeet v3 CoreML model files when intentionally updating the upstream model commit. |
 | `icon/` | SVG sources (`hero.svg`, `latency.svg`, `presspeech.svg`, etc.), `Presspeech.icns`, menu-bar PNGs, `make-icons.sh`. |
 | `experiments/swift-bench/` | Standalone ASR latency benchmark used to validate FluidAudio against alternatives (Apple SpeechAnalyzer, presspeech-mlx) on the same audio. Re-run when bumping FluidAudio or evaluating a backend swap. |
+| `windows/` | Windows tray implementation in Python. `app.py` owns hotkey/audio/paste lifecycle, `engine.py` owns local ASR backends, and `tests/` contains pure unit tests. Keep virtual environments, model caches, logs, and private benchmark recordings out of Git. |
 
 ## Build & test
 
@@ -96,6 +98,21 @@ maintainer's Mac.
 
 If you need to validate ASR latency or correctness, use
 `experiments/swift-bench/` against the WAVs in `test-audio/`.
+
+For Windows changes, use Python 3.12 from the implementation's virtual
+environment (never a system Python):
+
+```bat
+cd windows
+.venv\Scripts\python -m unittest discover -s tests -v
+.venv\Scripts\python app.py --selftest
+```
+
+The unit suite is model-free. The self-test loads the configured model and is
+the end-to-end CUDA/ASR check. Preserve the TDT decode call with
+`durations=output.durations`; omitting durations can truncate words. Keep
+`well` out of the filler-word regex, keep the pynput Right Alt/AltGr mapping,
+and do not replace the epoch-guarded post-roll timer with a blocking stop.
 
 ## Swift concurrency model — important
 
@@ -185,7 +202,7 @@ Accessibility, and Input Monitoring once to the current identity.
 
 ## Conventions
 
-- **One app file.** `main.swift` is the whole app (currently about 12k lines).
+- **One macOS app file.** `main.swift` is the whole macOS app (currently about 12k lines).
   Resist splitting it into separate `.swift` files unless a piece is
   genuinely decoupled and testable in isolation (which, given the
   AVFoundation / AppKit / ApplicationServices / FluidAudio
@@ -219,10 +236,11 @@ Accessibility, and Input Monitoring once to the current identity.
 - **Cloud transcription backends.** Presspeech is local-only by design.
   Audio never leaves the Mac (one-time exception: the model
   download from Hugging Face on first launch).
-- **Cross-platform.** Heavy macOS dependencies (AVFoundation,
-  AppKit, AudioToolbox, ApplicationServices, CoreGraphics, IOKit,
-  NSAppleScript, FluidAudio's CoreML path). Linux/Windows ports
-  belong in separate forks if anyone wants to do them.
+- **Shared cross-platform UI/runtime code.** The macOS implementation depends on
+  AVFoundation/AppKit/CoreML and the Windows implementation depends on native
+  Windows APIs, PortAudio, pynput, and CUDA. Keep platform implementations
+  isolated rather than building a leaky common abstraction. Linux is not
+  currently supported.
 - **AI rewriting / Presspeech-operated cloud sync / preference windows.**
   The README's opener positions Presspeech as focused push-to-talk
   dictation. Text-correction portability is intentionally limited to

--- a/README.md
+++ b/README.md
@@ -13,9 +13,16 @@
 
 # Presspeech
 
-**Private push-to-talk dictation into any Mac app.** Hold a key, speak,
+**Private push-to-talk dictation into any app.** Hold a key, speak,
 release, and the transcript appears at the cursor. No account, no
 subscription, no cloud transcription.
+
+Presspeech now has two platform implementations:
+
+- **macOS:** the released native Swift app for Apple Silicon, documented below.
+- **Windows:** the Python/CUDA implementation in [`windows/`](windows/README.md),
+  with Right Alt hold-to-talk, Parakeet TDT v3, a tray app, audio cues,
+  playback muting, and a compact on-screen status indicator.
 
 > Presspeech now uses the `com.local.presspeech` identity throughout.
 > When upgrading from an earlier identity, saved preferences and local
@@ -185,6 +192,19 @@ Key files:
 - `experiments/swift-bench/` — latency benchmark harness
 
 Release notes live in `swift/release-notes/`.
+
+For the Windows implementation:
+
+```bat
+cd windows
+py -3.12 -m venv .venv
+.venv\Scripts\python -m pip install -r requirements.txt
+.venv\Scripts\python -m pip install torch --index-url https://download.pytorch.org/whl/cu126
+.venv\Scripts\python -m unittest discover -s tests -v
+run.bat
+```
+
+See [`windows/README.md`](windows/README.md) for hardware, setup, and usage details.
 
 ## Links
 

--- a/windows/.gitignore
+++ b/windows/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.py[cod]
+benchmarks/
+build/
+dist/
+*.log
+presspeech_last.wav

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,102 @@
+# Presspeech for Windows
+
+Fast, private, local push-to-talk dictation for Windows — a Windows port of
+[presspeech](https://github.com/rcourtman/presspeech) (macOS). Hold a hotkey,
+speak, release, and the transcript is typed at the cursor. No cloud, no
+accounts, no telemetry — speech recognition runs entirely on your machine.
+
+Default engine: **NVIDIA Parakeet-TDT-0.6B-v3** — the same model family
+Presspeech uses on macOS. On an NVIDIA GPU (CUDA) it transcribes with
+punctuation and capitalization in a fraction of real time (~50× realtime on an
+RTX 3070). Parakeet loads in FP16 on CUDA to halve resident model tensors, with
+an automatic FP32 retry if the half-precision load fails. Whisper
+(`faster-whisper`) models are available as faster/lighter alternatives and as
+automatic fallback.
+
+## Install
+
+Prerequisite: Python 3.11+ (`winget install Python.Python.3.12`) and, for the
+Parakeet engine, an NVIDIA GPU with a current driver.
+
+```bat
+python -m venv .venv
+.venv\Scripts\pip install -r requirements.txt
+.venv\Scripts\pip install torch --index-url https://download.pytorch.org/whl/cu126
+run.bat
+```
+
+First launch downloads the Parakeet model once (~2.5 GB) into
+`%USERPROFILE%\.cache\huggingface`, then loads and warms it in the background
+so the first dictation is ready. First recording triggers the Windows
+microphone permission prompt — allow it.
+
+## Use
+
+1. Hold **Right Alt** (configurable).
+2. Speak.
+3. Release — the punctuated transcript appears at the cursor moments later.
+
+A short high tone confirms recording has started and a lower tone confirms it has
+stopped. Audio cues are enabled by default and can be disabled in Settings.
+
+After release, silence-aware post-roll stops as early as 80 ms while retaining
+the original 400 ms safety ceiling whenever speech is still present. This keeps
+final words intact without always paying the full delay.
+
+The model stays loaded during normal use so every dictation is immediately ready.
+The internal unload support is retained for an explicit gaming mode rather than
+being triggered merely because dictation has been idle.
+
+When a Moonlight stream is focused, Presspeech automatically uses Moonlight's
+clipboard-typing shortcut so transcripts reach the remote host, including macOS.
+Microsoft Remote Desktop is also detected automatically and uses its redirected
+clipboard with a small reliability delay. Normal Windows apps retain fast Ctrl+V.
+
+Tray icon (bottom-right) menus: **Dictate** (toggle), **Try Dictation…**
+(scratchpad that doesn't paste anywhere), **Settings…**, **Exit**. The icon
+turns red while recording.
+
+## Settings
+
+- Hotkey: right/left Alt, Ctrl, Shift, Win, or F8–F12
+- Trigger: hold-to-talk or press-to-toggle
+- Microphone: automatic selection or a specific safe Windows input device
+- Engine/model: Parakeet TDT v3 (GPU, best), Whisper turbo/small/medium/base
+- After pasting: space / newline / nothing
+- Remove filler words (um, uh, er, …)
+- British English spelling (color → colour, realize → realise)
+- Audio cues when dictation starts and stops
+- Mute speaker playback while recording, restoring its previous state afterwards
+- A click-through **Listening… / Transcribing…** indicator on the active display
+- Dictionary: map a misheard phrase or spoken shortcut to exact text
+  (e.g. "press speech" → `presspeech`), applied deterministically
+- Start with Windows (registry `HKCU\...\Run`)
+
+## Notes
+
+- A working microphone must be connected. Automatic selection prefers the
+  Windows Sound Mapper, skips virtual/loopback and WDM-KS devices, and resamples
+  to 16 kHz. A specific safe input can be selected in Settings.
+- Single-instance (named mutex) — launching twice does nothing.
+- All audio is processed in memory and discarded after transcription.
+- Transcript content is never written to logs; diagnostics retain timings and
+  character counts only.
+- Clipboard is used briefly to paste; it is overwritten.
+- `python app.py --selftest` verifies the engine pipeline.
+- `python benchmark.py` runs the repeatable local latency/accuracy evaluation;
+  see `benchmarks/README.md` for the reviewed-reference workflow.
+- If you see missing-DLL errors, install the Visual C++ Redistributable
+  (x64) from Microsoft.
+
+## Develop and test
+
+Always run the Windows code with its project virtual environment:
+
+```bat
+.venv\Scripts\python -m unittest discover -s tests -v
+.venv\Scripts\python app.py --selftest
+```
+
+The unit tests do not load a speech model. The self-test does, and therefore
+also verifies the installed Torch/CUDA/model pipeline. Local benchmark audio,
+results, virtual environments, caches, and logs are ignored by Git.

--- a/windows/app.py
+++ b/windows/app.py
@@ -1,0 +1,990 @@
+"""Presspeech for Windows - local push-to-talk dictation.
+
+Hold a hotkey, speak, release, and the transcript is typed at the cursor.
+Everything runs locally (Whisper via faster-whisper); no cloud, no accounts.
+"""
+
+import math
+import os
+import re
+import struct
+import sys
+import threading
+import time
+import traceback
+import winsound
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import sounddevice as sd
+import pyperclip
+from pynput import keyboard as pkb
+from PIL import Image, ImageDraw
+from pystray import Icon, Menu, MenuItem
+
+import config as cfg
+import engine
+import ui
+from british import to_british
+
+KEY_MAP = {
+    "right alt": {pkb.Key.alt_gr, pkb.Key.alt_r},
+    "left alt": {pkb.Key.alt_l, pkb.Key.alt_gr},
+    "right ctrl": {pkb.Key.ctrl_r},
+    "left ctrl": {pkb.Key.ctrl_l},
+    "right shift": {pkb.Key.shift_r},
+    "left shift": {pkb.Key.shift_l},
+    "right win": {pkb.Key.cmd_r},
+    "left win": {pkb.Key.cmd_l},
+    "f8": {pkb.Key.f8},
+    "f9": {pkb.Key.f9},
+    "f10": {pkb.Key.f10},
+    "f11": {pkb.Key.f11},
+    "f12": {pkb.Key.f12},
+}
+
+FILLER_RE = re.compile(
+    r"\b(?:u+m+|u+h+|a+h+|e+r+|e+r+m+|h+m+|h+m+m+|h+u+h+)\b", re.IGNORECASE
+)
+
+SINGLE_INSTANCE_MUTEX = "Local\\PresspeechSingleInstance"
+
+POST_ROLL_MIN_SEC = 0.08
+POST_ROLL_MAX_SEC = 0.4
+POST_ROLL_CHECK_SEC = 0.04
+POST_ROLL_TAIL_SEC = 0.09
+POST_ROLL_ABS_SILENCE_RMS = 0.003
+POST_ROLL_RELATIVE_SILENCE = 0.06
+POST_ROLL_MAX_SILENCE_RMS = 0.012
+# Backwards-compatible conservative value used by the benchmark's worst-case estimate.
+POST_ROLL_SEC = POST_ROLL_MAX_SEC
+MODEL_WARMUP_SEC = 8.0
+MODEL_IDLE_WAKE_SEC = 60.0
+PASTE_DELAY_SEC = 0.01
+RDP_PASTE_DELAY_SEC = 0.08
+
+MOONLIGHT_PROCESSES = {"moonlight.exe"}
+RDP_PROCESSES = {"mstsc.exe", "msrdc.exe"}
+
+AUTO_INPUT_DEVICE = "auto"
+INPUT_DEVICE_SKIP_WORDS = (
+    "stereo mix", "steam", "stream", "virtual", "loopback", "aux", "line in",
+    "hyperx",
+)
+UNSAFE_INPUT_HOST_APIS = ("wdm-ks",)
+
+LOG_PATH = os.path.join(cfg.CONFIG_DIR, "log.txt")
+
+
+def _make_cue_wave(frequency, duration=0.055, volume=0.14, sample_rate=24000):
+    """Build a short, softly faded mono WAV for native Windows playback."""
+    frame_count = int(duration * sample_rate)
+    fade_in = max(1, int(0.006 * sample_rate))
+    fade_out = max(1, int(0.014 * sample_rate))
+    frames = bytearray(frame_count * 2)
+    for i in range(frame_count):
+        envelope = min(1.0, i / fade_in, (frame_count - 1 - i) / fade_out)
+        value = int(32767 * volume * envelope *
+                    math.sin(2.0 * math.pi * frequency * i / sample_rate))
+        struct.pack_into("<h", frames, i * 2, value)
+    header = (
+        b"RIFF" + struct.pack("<I", 36 + len(frames)) + b"WAVEfmt " +
+        struct.pack("<IHHIIHH", 16, 1, 1, sample_rate,
+                    sample_rate * 2, 2, 16) +
+        b"data" + struct.pack("<I", len(frames))
+    )
+    return header + bytes(frames)
+
+
+CUE_SOUNDS = {
+    "start": _make_cue_wave(880),
+    "stop": _make_cue_wave(620),
+}
+
+
+def _mute_default_playback():
+    """Mute the current default render endpoint and return its prior state."""
+    import comtypes
+    from pycaw.pycaw import AudioUtilities
+
+    comtypes.CoInitialize()
+    try:
+        device = AudioUtilities.GetSpeakers()
+        volume = device.EndpointVolume
+        was_muted = bool(volume.GetMute())
+        volume.SetMute(1, None)
+        return device.id, was_muted
+    finally:
+        comtypes.CoUninitialize()
+
+
+def _restore_playback_mute(endpoint_id, was_muted):
+    """Restore the saved mute state on the endpoint muted for recording."""
+    import comtypes
+    from pycaw.pycaw import AudioUtilities
+
+    comtypes.CoInitialize()
+    try:
+        default = AudioUtilities.GetSpeakers()
+        if default.id.lower() == endpoint_id.lower():
+            device = default
+        else:
+            device = next(
+                (item for item in AudioUtilities.GetAllDevices()
+                 if item.id.lower() == endpoint_id.lower()),
+                None,
+            )
+        if device is None:
+            return False
+        device.EndpointVolume.SetMute(1 if was_muted else 0, None)
+        return True
+    finally:
+        comtypes.CoUninitialize()
+
+
+def _resample_to_16k(audio, from_rate):
+    """Resample a mono float32 array to 16 kHz (48k = exact /3 decimation)."""
+    if from_rate == 16000:
+        return audio
+    if from_rate == 48000:
+        n = len(audio) // 3 * 3
+        if n < 3:
+            return audio
+        return audio[:n].reshape(-1, 3).mean(axis=1)
+    duration = len(audio) / float(from_rate)
+    out_n = int(round(duration * 16000))
+    if out_n < 2:
+        return audio
+    x = np.linspace(0.0, len(audio) - 1.0, out_n)
+    xi = np.floor(x).astype(np.int64)
+    frac = (x - xi).astype(np.float32)
+    xi = np.clip(xi, 0, len(audio) - 2)
+    return audio[xi] * (1.0 - frac) + audio[xi + 1] * frac
+
+
+def _foreground_process_name():
+    """Return the executable owning the foreground window, or an empty string."""
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        user32 = ctypes.WinDLL("user32", use_last_error=True)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        user32.GetForegroundWindow.restype = wintypes.HWND
+        user32.GetWindowThreadProcessId.argtypes = [wintypes.HWND,
+                                                    ctypes.POINTER(wintypes.DWORD)]
+        kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL,
+                                         wintypes.DWORD]
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.QueryFullProcessImageNameW.argtypes = [
+            wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+
+        hwnd = user32.GetForegroundWindow()
+        if not hwnd:
+            return ""
+        process_id = wintypes.DWORD()
+        user32.GetWindowThreadProcessId(hwnd, ctypes.byref(process_id))
+        handle = kernel32.OpenProcess(0x1000, False, process_id.value)
+        if not handle:
+            return ""
+        try:
+            size = wintypes.DWORD(32768)
+            path = ctypes.create_unicode_buffer(size.value)
+            if not kernel32.QueryFullProcessImageNameW(
+                    handle, 0, path, ctypes.byref(size)):
+                return ""
+            return os.path.basename(path.value).lower()
+        finally:
+            kernel32.CloseHandle(handle)
+    except Exception:
+        return ""
+
+
+def _paste_route(process_name):
+    """Choose a paste method for the application receiving the transcript."""
+    name = (process_name or "").lower()
+    if name in MOONLIGHT_PROCESSES:
+        return "moonlight"
+    if name in RDP_PROCESSES:
+        return "rdp"
+    return "local"
+
+
+def _make_icon(color):
+    img = Image.new("RGBA", (64, 64), (0, 0, 0, 0))
+    d = ImageDraw.Draw(img)
+    d.ellipse((3, 3, 61, 61), fill=color + (255,))
+    d.rounded_rectangle((23, 13, 41, 33), radius=7, fill=(255, 255, 255, 255))
+    d.ellipse((19, 29, 45, 45), fill=(255, 255, 255, 255))
+    d.rounded_rectangle((28, 38, 36, 52), radius=4, fill=(255, 255, 255, 255))
+    d.ellipse((24, 48, 40, 56), fill=(255, 255, 255, 255))
+    return img
+
+
+class PresspeechApp:
+    def __init__(self):
+        self.settings = cfg.load()
+        self.transcriber = engine.Transcriber(
+            precision=self.settings.get("precision", "fp16"))
+        self.buffer = []
+        self.stream = None
+        self.recording = False
+        self.lock = threading.Lock()
+        self.paste_target = "paste"
+        self.scratchpad = None
+        self.settings_window = None
+        self.icon = None
+        self.listener = None
+        self._mutex_handle = None
+        self._key_held = False
+        self._injecting_keys = False
+        self._recording_target_process = ""
+        self._rec_epoch = 0
+        self._peak_rms = 0.0
+        self._last_model_use = 0.0
+        self._wake_in_progress = False
+        self._wake_lock = threading.Lock()
+        # Keep every model operation on one permanent OS thread. CUDA/cuDNN
+        # execution state is thread-affine enough that creating a fresh worker
+        # per dictation costs roughly one second even with fixed input shapes.
+        self._model_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="presspeech-model")
+        self._model_idle_epoch = 0
+        self._playback_mute_lock = threading.Lock()
+        self._playback_restore = None
+        self.indicator = ui.DictationIndicator()
+        self.input_device = None
+        self.idle_icon = _make_icon((140, 140, 140))
+        self.rec_icon = _make_icon((225, 60, 60))
+
+    # ---------------- lifecycle ----------------
+
+    def run(self):
+        if not self._single_instance():
+            print("Presspeech is already running.")
+            sys.exit(1)
+        self.icon = Icon(
+            "Presspeech",
+            self.idle_icon,
+            "Presspeech - push-to-talk dictation",
+            menu=Menu(
+                MenuItem("Dictate", self.toggle_dictate, default=True),
+                MenuItem("Try Dictation\u2026", self.open_scratchpad),
+                MenuItem("Settings\u2026", self.open_settings),
+                Menu.SEPARATOR,
+                MenuItem("Exit", self.exit_app),
+            ),
+        )
+        threading.Thread(target=self.icon.run, daemon=True).start()
+        self.listener = pkb.Listener(on_press=self._on_press, on_release=self._on_release)
+        self.listener.start()
+        self._log("running; hotkey=%s trigger=%s" % (self.settings["hotkey"], self.settings["trigger"]))
+        self._model_executor.submit(self._preload_model_worker)
+        try:
+            while True:
+                threading.Event().wait(3600)
+        except KeyboardInterrupt:
+            pass
+
+    def _single_instance(self):
+        import ctypes
+        from ctypes import wintypes
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.CreateMutexW.restype = wintypes.HANDLE
+        kernel32.CreateMutexW.argtypes = [wintypes.LPVOID, wintypes.BOOL, wintypes.LPCWSTR]
+        handle = kernel32.CreateMutexW(None, False, SINGLE_INSTANCE_MUTEX)
+        if not handle:
+            return False
+        if ctypes.get_last_error() == 183:  # ERROR_ALREADY_EXISTS
+            return False
+        self._mutex_handle = handle
+        return True
+
+    def exit_app(self, icon=None, item=None):
+        self._restore_playback_after_recording()
+        self.indicator.close()
+        if self.listener is not None:
+            self.listener.stop()
+        for win in (self.scratchpad, self.settings_window):
+            if win is not None and win.root is not None:
+                try:
+                    win.root.after(0, win.root.destroy)
+                except Exception:
+                    pass
+        if self.icon is not None:
+            self.icon.stop()
+        os._exit(0)
+
+    # ---------------- hotkey ----------------
+
+    def _is_hotkey(self, key):
+        return key in KEY_MAP.get(self.settings["hotkey"], set())
+
+    def _on_press(self, key):
+        if self._injecting_keys:
+            return
+        if not self._is_hotkey(key):
+            return
+        if self._key_held:
+            return
+        self._key_held = True
+        self._log("key down: %s" % (key,))
+        if self.settings["trigger"] == "toggle":
+            if self.recording:
+                self.request_stop()
+            else:
+                self.start_recording()
+        else:
+            self.start_recording()
+
+    def _on_release(self, key):
+        if self._injecting_keys:
+            return
+        if not self._is_hotkey(key):
+            return
+        self._key_held = False
+        self._log("key up: %s" % (key,))
+        if self.settings["trigger"] != "toggle":
+            self.request_stop()
+
+    def toggle_dictate(self, icon=None, item=None):
+        if self.recording:
+            self.request_stop()
+        else:
+            self.start_recording()
+
+    # ---------------- recording ----------------
+
+    def start_recording(self):
+        target_process = _foreground_process_name()
+        with self.lock:
+            self._rec_epoch += 1
+            if self.recording:
+                return
+            self.recording = True
+            self.buffer = []
+            self._peak_rms = 0.0
+            self._model_idle_epoch += 1
+            self._recording_target_process = target_process
+        self._log("recording started")
+        self._set_indicator("listening")
+        self._wake_model_if_idle()
+        threading.Thread(target=self._start_audio_worker, daemon=True).start()
+
+    def _start_audio_worker(self):
+        # Finish the audible cue before muting, and mute before opening the mic,
+        # so neither the cue nor existing speaker audio is captured.
+        if self.settings.get("audio_cues", True):
+            self._play_cue_worker("start")
+        self._mute_playback_for_recording()
+        self._open_mic_worker()
+
+    def _mute_playback_for_recording(self):
+        if not self.settings.get("mute_playback_while_recording", True):
+            return
+        with self._playback_mute_lock:
+            with self.lock:
+                if not self.recording:
+                    return
+            if self._playback_restore is not None:
+                return
+            try:
+                self._playback_restore = _mute_default_playback()
+                self._log("playback muted for recording")
+            except Exception as exc:
+                self._log("could not mute playback: %s" % exc)
+
+    def _restore_playback_after_recording(self):
+        with self._playback_mute_lock:
+            saved = self._playback_restore
+            self._playback_restore = None
+            if saved is None:
+                return
+            try:
+                restored = _restore_playback_mute(*saved)
+                if restored:
+                    self._log("playback mute state restored")
+                else:
+                    self._log("playback endpoint disappeared before mute restore")
+            except Exception as exc:
+                self._log("could not restore playback mute state: %s" % exc)
+
+    def _open_mic_worker(self):
+        try:
+            chosen = self._get_input_device()
+            if chosen is None:
+                with self.lock:
+                    self.recording = False
+                self._restore_playback_after_recording()
+                self._set_indicator(None)
+                self._log("no working microphone found")
+                self.notify("No microphone found",
+                            "Plug in a microphone or check Windows Sound settings "
+                            "(Recording tab), then try again.")
+                return
+            self.input_device = chosen
+            idx, rate = chosen
+            stream = sd.InputStream(
+                device=idx, samplerate=rate, channels=1, dtype="float32",
+                callback=self._audio_cb,
+            )
+            stream.start()
+            with self.lock:
+                if not self.recording:
+                    self.stream = None
+                else:
+                    self.stream = stream
+            if self.stream is None:
+                try:
+                    stream.stop()
+                    stream.close()
+                except Exception:
+                    pass
+                return
+        except Exception as exc:
+            with self.lock:
+                self.recording = False
+                self.stream = None
+            self._restore_playback_after_recording()
+            self._set_indicator(None)
+            self._log("mic error: %s" % exc)
+            self.notify("Microphone error", str(exc))
+            return
+        self._log("mic open ok: %s" % (self.input_device,))
+        if self.icon is not None:
+            self.icon.icon = self.rec_icon
+
+    def _audio_cb(self, indata, frames, time_info, status):
+        chunk = indata.copy()
+        chunk_rms = float(np.sqrt(np.mean(np.square(chunk)))) if chunk.size else 0.0
+        with self.lock:
+            if self.recording:
+                self.buffer.append(chunk)
+                self._peak_rms = max(self._peak_rms, chunk_rms)
+
+    def request_stop(self):
+        """Stop after silence, retaining the full safety window for ongoing speech."""
+        self._rec_epoch += 1
+        self._schedule_post_roll(
+            POST_ROLL_MIN_SEC, self._rec_epoch, time.perf_counter())
+
+    def _schedule_post_roll(self, delay, epoch, released_at):
+        timer = threading.Timer(delay, self._finish_after_roll, (epoch, released_at))
+        timer.daemon = True
+        timer.start()
+
+    def _post_roll_tail(self):
+        with self.lock:
+            rate = self.input_device[1] if self.input_device is not None else 16000
+            needed = max(1, int(rate * POST_ROLL_TAIL_SEC))
+            remaining = needed
+            parts = []
+            for chunk in reversed(self.buffer):
+                flat = chunk.reshape(-1)
+                take = min(remaining, flat.size)
+                if take:
+                    parts.append(flat[-take:])
+                    remaining -= take
+                if remaining == 0:
+                    break
+            peak_rms = self._peak_rms
+        if not parts:
+            tail_rms = 0.0
+        else:
+            tail = np.concatenate(list(reversed(parts)))
+            tail_rms = float(np.sqrt(np.mean(np.square(tail))))
+        threshold = min(
+            POST_ROLL_MAX_SILENCE_RMS,
+            max(POST_ROLL_ABS_SILENCE_RMS,
+                peak_rms * POST_ROLL_RELATIVE_SILENCE),
+        )
+        return tail_rms, threshold
+
+    def _finish_after_roll(self, epoch, released_at):
+        if epoch != self._rec_epoch:
+            return
+        elapsed = time.perf_counter() - released_at
+        tail_rms, threshold = self._post_roll_tail()
+        silent = tail_rms <= threshold
+        if silent or elapsed >= POST_ROLL_MAX_SEC:
+            reason = "silence" if silent else "maximum"
+            self._log("post-roll %.3fs (%s; rms %.4f, threshold %.4f)" %
+                      (elapsed, reason, tail_rms, threshold))
+            self.stop_recording()
+            return
+        remaining = POST_ROLL_MAX_SEC - elapsed
+        self._schedule_post_roll(
+            min(POST_ROLL_CHECK_SEC, max(0.0, remaining)), epoch, released_at)
+
+    def stop_recording(self):
+        with self.lock:
+            if not self.recording:
+                return
+            self.recording = False
+            audio = np.concatenate(self.buffer) if self.buffer else np.zeros(0, dtype=np.float32)
+            target_process = self._recording_target_process
+            self.buffer = []
+        if self.stream is not None:
+            try:
+                self.stream.stop()
+                self.stream.close()
+            except Exception:
+                pass
+            self.stream = None
+        if self.icon is not None:
+            self.icon.icon = self.idle_icon
+        # Restore playback only after closing the stream, so returning speaker
+        # audio and the stop cue are never captured in the post-roll.
+        self._restore_playback_after_recording()
+        self._play_cue("stop")
+        if audio.size == 0:
+            self._set_indicator(None)
+            self._log("recording stopped; no audio captured")
+            self._schedule_model_idle_unload()
+            return
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1)
+        if self.input_device is not None and self.input_device[1] != 16000:
+            audio = _resample_to_16k(audio, self.input_device[1])
+        if audio.size / 16000.0 < 0.25:
+            self._set_indicator(None)
+            self._log("recording stopped; too short (%.2fs)" % (audio.size / 16000.0))
+            self._schedule_model_idle_unload()
+            return
+        self._capture_benchmark_if_armed(audio)
+        self._set_indicator("transcribing")
+        self._log("recording stopped; %.2fs captured, transcribing" % (audio.size / 16000.0))
+        self._model_executor.submit(
+            self._transcribe_worker, audio, target_process)
+
+    def _capture_benchmark_if_armed(self, audio):
+        """Persist only explicitly armed recordings for local model comparison."""
+        remaining = int(self.settings.get("capture_benchmark_remaining", 0) or 0)
+        one_shot = bool(self.settings.get("capture_next_benchmark", False))
+        if remaining <= 0 and not one_shot:
+            return None
+        output_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                  "benchmarks", "audio")
+        session = self.settings.get("capture_benchmark_session", "").strip()
+        index = int(self.settings.get("capture_benchmark_index", 1) or 1)
+        safe_session = re.sub(r"[^A-Za-z0-9_-]+", "-", session).strip("-")
+        if remaining > 0 and safe_session:
+            filename = "%s-%02d.wav" % (safe_session, index)
+        else:
+            filename = "live-%s.wav" % time.strftime("%Y%m%d-%H%M%S")
+        output_path = os.path.join(output_dir, filename)
+        try:
+            import wave
+            os.makedirs(output_dir, exist_ok=True)
+            pcm = (np.clip(audio, -1, 1) * 32767).astype(np.int16)
+            with wave.open(output_path, "wb") as handle:
+                handle.setnchannels(1)
+                handle.setsampwidth(2)
+                handle.setframerate(16000)
+                handle.writeframes(pcm.tobytes())
+            self.settings["capture_next_benchmark"] = False
+            if remaining > 0:
+                self.settings["capture_benchmark_remaining"] = remaining - 1
+                self.settings["capture_benchmark_index"] = index + 1
+            cfg.save(self.settings)
+            self._log("saved one-shot benchmark audio: %s" % output_path)
+            left = max(0, remaining - 1) if remaining > 0 else 0
+            self.notify("Benchmark clip saved", "%s (%d remaining)" %
+                        (os.path.basename(output_path), left))
+            return output_path
+        except Exception as exc:
+            self._log("benchmark capture failed: %s" % exc)
+            self.notify("Benchmark capture failed", str(exc))
+            return None
+
+    # ---------------- input device selection ----------------
+
+    @staticmethod
+    def _device_selector(device, host_name):
+        """Return a stable selector that does not depend on PortAudio device indexes."""
+        return "%s::%s" % (host_name, device["name"])
+
+    @staticmethod
+    def _safe_input_device(device, host_name):
+        if device["max_input_channels"] < 1:
+            return False
+        name = device["name"].lower()
+        host_name = host_name.lower()
+        if any(word in name for word in INPUT_DEVICE_SKIP_WORDS):
+            return False
+        return not any(word in host_name for word in UNSAFE_INPUT_HOST_APIS)
+
+    def input_device_options(self):
+        """Return (label, selector) pairs for Settings, excluding unsafe devices."""
+        options = [("Automatic (recommended)", AUTO_INPUT_DEVICE)]
+        try:
+            devices = sd.query_devices()
+            host_apis = sd.query_hostapis()
+        except Exception as exc:
+            self._log("could not list input devices: %s" % exc)
+            return options
+        for i, device in enumerate(devices):
+            host_name = host_apis[device["hostapi"]]["name"]
+            if not self._safe_input_device(device, host_name):
+                continue
+            label = "%s — %s (device %d)" % (device["name"], host_name, i)
+            options.append((label, self._device_selector(device, host_name)))
+        return options
+
+    def _get_input_device(self):
+        if self.input_device is not None:
+            return self.input_device
+        devices = sd.query_devices()
+        host_apis = sd.query_hostapis()
+        selected = self.settings.get("input_device", AUTO_INPUT_DEVICE)
+        host_pref = {"mme": 0, "windows directsound": 1, "windows wasapi": 2}
+        ranked = []
+        for i, d in enumerate(devices):
+            host_name = host_apis[d["hostapi"]]["name"]
+            if not self._safe_input_device(d, host_name):
+                continue
+            name = d["name"].lower()
+            selector = self._device_selector(d, host_name)
+            score = host_pref.get(host_name.lower(), 9) * 10
+            if name == "microsoft sound mapper - input":
+                score -= 100
+            elif "yeti nano" in name:
+                score -= 10
+            if "microphone" in name or "mic" in name:
+                score -= 1
+            else:
+                score += 1
+            selected_first = 0 if selected != AUTO_INPUT_DEVICE and selector == selected else 1
+            ranked.append((selected_first, score, i, d, host_name, selector))
+        ranked.sort(key=lambda t: (t[0], t[1], t[2]))
+        if selected != AUTO_INPUT_DEVICE:
+            # An explicit device choice is strict. If it disappears or cannot be
+            # opened, fail safely instead of silently recording from another mic.
+            ranked = [item for item in ranked if item[5] == selected]
+            if not ranked:
+                self._log("configured input is unavailable: %s" % selected)
+                return None
+        for _selected_first, _score, i, d, _host_name, selector in ranked:
+            for rate in (16000, 48000, 44100):
+                try:
+                    sd.check_input_settings(device=i, samplerate=rate, channels=1,
+                                            dtype="float32")
+                except Exception:
+                    continue
+                if self._probe_input(i, rate):
+                    self.input_device = (i, rate)
+                    chosen_for = "configured" if selector == selected else "automatic"
+                    self._log("using %s input: %s at %d Hz" %
+                              (chosen_for, d["name"], rate))
+                    return self.input_device
+        return None
+
+    @staticmethod
+    def _probe_input(idx, rate):
+        got = threading.Event()
+
+        def cb(indata, frames, t, status):
+            got.set()
+
+        try:
+            s = sd.InputStream(device=idx, samplerate=rate, channels=1, dtype="float32",
+                               callback=cb)
+            s.start()
+            ok = got.wait(0.8)
+            s.stop()
+            s.close()
+            return ok
+        except Exception:
+            return False
+
+    # ---------------- transcription ----------------
+
+    def _transcribe_worker(self, audio, target_process=""):
+        try:
+            return self._transcribe_worker_inner(audio, target_process)
+        finally:
+            self._set_indicator(None)
+
+    def _transcribe_worker_inner(self, audio, target_process=""):
+        model_started = time.perf_counter()
+        try:
+            if not self.transcriber.loaded(self.settings["model"]):
+                self.transcriber.load(self.settings["model"], notify=self.notify)
+            text = self.transcriber.transcribe(audio, language="en")
+            model_seconds = time.perf_counter() - model_started
+        except Exception as exc:
+            self._log(traceback.format_exc())
+            if not engine.is_parakeet(self.settings["model"]):
+                self.notify("Transcription failed", str(exc))
+                return
+            try:
+                self.notify("Parakeet failed", "Falling back to Whisper base.en (%s)"
+                            % str(exc)[:100])
+                self.transcriber.load("base.en", notify=self.notify)
+                model_started = time.perf_counter()
+                text = self.transcriber.transcribe(audio, language="en")
+                model_seconds = time.perf_counter() - model_started
+            except Exception as exc2:
+                self._log(traceback.format_exc())
+                self.notify("Transcription failed", str(exc2))
+                return
+        if not text:
+            self._log("transcription returned empty")
+            return
+        text = self._apply_text(text)
+        self._last_model_use = time.perf_counter()
+        self._schedule_model_idle_unload()
+        # Dictation is private: retain performance data without persisting the
+        # user's words in the diagnostic log.
+        self._log("transcription complete: %d chars (model %.3fs)" %
+                  (len(text), model_seconds))
+        timing = getattr(self.transcriber, "last_timing", {})
+        if timing:
+            self._log(
+                "model detail: backend=%s bucket=%s lock=%.3fs prepare=%.3fs "
+                "transfer=%.3fs generate=%.3fs decode=%.3fs" % (
+                    timing.get("backend", ""),
+                    timing.get("bucket_seconds", "-"),
+                    timing.get("lock_wait", 0.0),
+                    timing.get("prepare", 0.0),
+                    timing.get("transfer", 0.0),
+                    timing.get("generate", timing.get("inference", 0.0)),
+                    timing.get("decode", 0.0),
+                ))
+        if self.paste_target == "scratchpad" and self.scratchpad is not None:
+            self.scratchpad.append_text(text)
+        else:
+            self._paste(text, target_process)
+
+    def _apply_text(self, text):
+        for spoken, replacement in self.settings["dictionary"]:
+            if spoken:
+                pattern = r"(?<!\w)%s(?!\w)" % re.escape(spoken)
+                text = re.sub(pattern, replacement, text, flags=re.IGNORECASE)
+        if self.settings["remove_fillers"]:
+            text = FILLER_RE.sub("", text)
+            text = re.sub(r"\s{2,}", " ", text).strip()
+        if self.settings.get("british"):
+            text = to_british(text)
+        text += cfg.SUFFIXES.get(self.settings["suffix"], " ")
+        return text
+
+    def _paste(self, text, target_process=""):
+        pyperclip.copy(text)
+        process_name = target_process or _foreground_process_name()
+        route = _paste_route(process_name)
+        time.sleep(RDP_PASTE_DELAY_SEC if route == "rdp" else PASTE_DELAY_SEC)
+        keyboard = pkb.Controller()
+        modifiers = [pkb.Key.ctrl_l]
+        if route == "moonlight":
+            # Moonlight's client-side shortcut types clipboard text on the host.
+            modifiers.extend((pkb.Key.alt_l, pkb.Key.shift_l))
+            self._log("paste route: Moonlight clipboard typing")
+        elif route == "rdp":
+            self._log("paste route: Remote Desktop clipboard")
+        else:
+            self._log("paste route: local (%s)" % (process_name or "unknown"))
+        self._injecting_keys = True
+        pressed = []
+        try:
+            for key in modifiers:
+                keyboard.press(key)
+                pressed.append(key)
+            keyboard.press("v")
+            keyboard.release("v")
+        finally:
+            for key in reversed(pressed):
+                keyboard.release(key)
+            # Let hook callbacks consume the injected releases before re-enabling PTT.
+            time.sleep(0.02)
+            self._injecting_keys = False
+
+    # ---------------- windows ----------------
+
+    def open_scratchpad(self, icon=None, item=None):
+        if self.scratchpad is None:
+            self.scratchpad = ui.ScratchpadWindow(self)
+
+    def open_settings(self, icon=None, item=None):
+        if self.settings_window is None:
+            self.settings_window = ui.SettingsWindow(self)
+
+    # ---------------- helpers ----------------
+
+    def apply_autostart(self):
+        enable = bool(self.settings["autostart"])
+        try:
+            import winreg
+            key = winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Run",
+                0,
+                winreg.KEY_SET_VALUE,
+            )
+            if enable:
+                exe = sys.executable
+                if exe.lower().endswith("python.exe"):
+                    candidate = os.path.join(os.path.dirname(exe), "pythonw.exe")
+                    if os.path.exists(candidate):
+                        exe = candidate
+                winreg.SetValueEx(key, "Presspeech", 0, winreg.REG_SZ,
+                                  '"%s" "%s"' % (exe, os.path.abspath(__file__)))
+            else:
+                try:
+                    winreg.DeleteValue(key, "Presspeech")
+                except FileNotFoundError:
+                    pass
+            winreg.CloseKey(key)
+        except Exception as exc:
+            self._log("autostart error: %s" % exc)
+
+    def notify(self, title, message):
+        try:
+            if self.icon is not None:
+                self.icon.notify(message, title)
+        except Exception:
+            pass
+
+    def _set_indicator(self, state):
+        indicator = getattr(self, "indicator", None)
+        if indicator is None:
+            return
+        try:
+            if state is None:
+                indicator.hide()
+            elif self.settings.get("visual_indicator", True):
+                indicator.show(state)
+        except Exception:
+            pass
+
+    def _play_cue(self, name):
+        if not self.settings.get("audio_cues", True):
+            return
+        threading.Thread(
+            target=self._play_cue_worker, args=(name,), daemon=True).start()
+
+    @staticmethod
+    def _play_cue_worker(name):
+        try:
+            winsound.PlaySound(
+                CUE_SOUNDS[name], winsound.SND_MEMORY | winsound.SND_NODEFAULT)
+        except (KeyError, RuntimeError):
+            pass
+
+    def _preload_model_worker(self):
+        """Warm the configured model in the tray process before the first dictation."""
+        model_name = self.settings["model"]
+        self._log("loading model at startup: %s" % model_name)
+        try:
+            self.transcriber.load(model_name, notify=self.notify)
+            self._log("warming model at startup")
+            self.transcriber.warmup(
+                seconds=MODEL_WARMUP_SEC, all_buckets=True)
+            # Warming long fixed shapes temporarily reserves CUDA workspace.
+            # The cuDNN execution plans stay cached after releasing unused
+            # allocator blocks, so first-pass speed is retained without
+            # needlessly occupying gaming VRAM.
+            try:
+                import torch
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            except Exception:
+                pass
+            self._last_model_use = time.perf_counter()
+        except Exception as exc:
+            self._log("startup model load failed: %s\n%s" % (exc, traceback.format_exc()))
+            self.notify("Model load failed", "%s will retry on first dictation." % model_name)
+            return
+        model_dtype = getattr(self.transcriber.model, "dtype", "unknown")
+        self._log("model ready: %s (%s)" % (model_name, model_dtype))
+        self._schedule_model_idle_unload()
+
+    def _wake_model_if_idle(self):
+        loaded = self.transcriber.loaded(self.settings["model"])
+        if (loaded and
+                time.perf_counter() - self._last_model_use < MODEL_IDLE_WAKE_SEC):
+            return
+        with self._wake_lock:
+            if self._wake_in_progress:
+                return
+            self._wake_in_progress = True
+        self._model_executor.submit(self._wake_model_worker)
+
+    def _wake_model_worker(self):
+        started = time.perf_counter()
+        try:
+            reloaded = False
+            if not self.transcriber.loaded(self.settings["model"]):
+                self._log("reloading model on hotkey: %s" % self.settings["model"])
+                self.transcriber.load(self.settings["model"], notify=self.notify)
+                reloaded = True
+            # A resident Parakeet needs only the smallest fixed shape to raise
+            # GPU clocks after a long idle. It starts at key-down and normally
+            # completes while the user is still speaking. A genuinely reloaded
+            # model warms every supported duration bucket.
+            self.transcriber.warmup(
+                seconds=1.0, all_buckets=reloaded)
+            self._last_model_use = time.perf_counter()
+            self._schedule_model_idle_unload()
+            self._log("idle model wake completed in %.3fs" %
+                      (self._last_model_use - started))
+        except Exception as exc:
+            self._log("idle model wake failed: %s" % exc)
+        finally:
+            with self._wake_lock:
+                self._wake_in_progress = False
+
+    def _schedule_model_idle_unload(self):
+        idle_seconds = int(self.settings.get("gpu_idle_unload_sec", 0) or 0)
+        if idle_seconds <= 0:
+            return
+        self._model_idle_epoch += 1
+        epoch = self._model_idle_epoch
+        timer = threading.Timer(idle_seconds, self._unload_model_if_idle, (epoch,))
+        timer.daemon = True
+        timer.start()
+
+    def _unload_model_if_idle(self, epoch):
+        if epoch != self._model_idle_epoch or self.recording:
+            return
+        if not self.transcriber.loaded(self.settings["model"]):
+            return
+        idle_seconds = int(self.settings.get("gpu_idle_unload_sec", 0) or 0)
+        elapsed = time.perf_counter() - self._last_model_use
+        if elapsed < idle_seconds:
+            self._schedule_model_idle_unload()
+            return
+        self.transcriber.unload()
+        self._log("model unloaded after %ds idle; hotkey remains active" % idle_seconds)
+
+    @staticmethod
+    def _log(message):
+        print("[presspeech] %s" % message, flush=True)
+        try:
+            os.makedirs(cfg.CONFIG_DIR, exist_ok=True)
+            with open(LOG_PATH, "a", encoding="utf-8") as fh:
+                fh.write(time.strftime("%H:%M:%S ") + message + "\n")
+        except Exception:
+            pass
+
+
+def _selftest():
+    settings = cfg.load()
+    transcriber = engine.Transcriber(precision=settings.get("precision", "fp16"))
+    model_name = settings["model"]
+    print("Loading %s model..." % model_name, flush=True)
+    transcriber.load(model_name, notify=lambda title, msg: print("  " + msg, flush=True))
+    print("Transcribing silent clip...", flush=True)
+    text = transcriber.transcribe(np.zeros(16000, dtype=np.float32), language="en")
+    print("Silent clip transcribed:", repr(text), flush=True)
+    print("Self-test OK.", flush=True)
+
+
+if __name__ == "__main__":
+    if "--selftest" in sys.argv:
+        _selftest()
+        sys.exit(0)
+    PresspeechApp().run()

--- a/windows/benchmark.py
+++ b/windows/benchmark.py
@@ -1,0 +1,275 @@
+"""Local, repeatable accuracy and latency benchmarks for Presspeech."""
+
+import argparse
+import collections
+import datetime as dt
+import json
+import math
+import os
+import platform
+import re
+import statistics
+import time
+
+import numpy as np
+import soundfile as sf
+
+import app
+import config as cfg
+import engine
+
+
+WORD_RE = re.compile(r"[\w']+", re.UNICODE)
+
+
+def _normalise_words(text):
+    text = text.lower().replace("\u2019", "'")
+    return WORD_RE.findall(text)
+
+
+def _normalise_chars(text):
+    text = text.lower().replace("\u2019", "'")
+    return " ".join(text.split())
+
+
+def edit_distance(reference, hypothesis):
+    """Levenshtein distance for token or character sequences."""
+    previous = list(range(len(hypothesis) + 1))
+    for i, ref_item in enumerate(reference, 1):
+        current = [i]
+        for j, hyp_item in enumerate(hypothesis, 1):
+            current.append(min(
+                current[-1] + 1,
+                previous[j] + 1,
+                previous[j - 1] + (ref_item != hyp_item),
+            ))
+        previous = current
+    return previous[-1]
+
+
+def accuracy_metrics(reference, hypothesis):
+    ref_words = _normalise_words(reference)
+    hyp_words = _normalise_words(hypothesis)
+    ref_chars = _normalise_chars(reference)
+    hyp_chars = _normalise_chars(hypothesis)
+    return {
+        "word_errors": edit_distance(ref_words, hyp_words),
+        "reference_words": len(ref_words),
+        "wer": (edit_distance(ref_words, hyp_words) / len(ref_words)
+                if ref_words else None),
+        "character_errors": edit_distance(ref_chars, hyp_chars),
+        "reference_characters": len(ref_chars),
+        "cer": (edit_distance(ref_chars, hyp_chars) / len(ref_chars)
+                if ref_chars else None),
+        "exact_match": _normalise_chars(reference) == _normalise_chars(hypothesis),
+    }
+
+
+def load_audio(path):
+    audio, sample_rate = sf.read(path, dtype="float32", always_2d=False)
+    if audio.ndim > 1:
+        audio = audio.mean(axis=1)
+    audio = np.asarray(audio, dtype=np.float32)
+    original_seconds = len(audio) / float(sample_rate)
+    if sample_rate != 16000:
+        audio = app._resample_to_16k(audio, sample_rate)
+    return audio, original_seconds, sample_rate
+
+
+def _sync_cuda():
+    try:
+        import torch
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+    except Exception:
+        pass
+
+
+def _percentile(values, percentile):
+    ordered = sorted(values)
+    index = max(0, math.ceil(percentile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def _environment():
+    result = {
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+    }
+    try:
+        import torch
+        result.update({
+            "torch": torch.__version__,
+            "cuda_available": torch.cuda.is_available(),
+            "cuda_device": (torch.cuda.get_device_name(0)
+                            if torch.cuda.is_available() else None),
+        })
+    except Exception as exc:
+        result["torch_error"] = str(exc)
+    return result
+
+
+def _apply_precision(transcriber, precision):
+    if precision == "auto":
+        return
+    if transcriber.backend != "parakeet":
+        raise ValueError("precision experiments currently support Parakeet only")
+    import torch
+    if precision == "tf32":
+        torch.set_float32_matmul_precision("high")
+        return
+    if not torch.cuda.is_available():
+        raise ValueError("half-precision experiments require CUDA")
+    dtype = {"fp16": torch.float16, "bf16": torch.bfloat16}[precision]
+    transcriber.model.to(dtype=dtype)
+
+
+def run_benchmark(manifest_path, model_name=None, runs=None, precision="auto"):
+    manifest_path = os.path.abspath(manifest_path)
+    manifest_dir = os.path.dirname(manifest_path)
+    with open(manifest_path, "r", encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    model_name = model_name or manifest.get("model") or cfg.DEFAULTS["model"]
+    runs = runs or int(manifest.get("runs", 3))
+    if runs < 1:
+        raise ValueError("runs must be at least 1")
+
+    transcriber = engine.Transcriber()
+    _sync_cuda()
+    started = time.perf_counter()
+    transcriber.load(model_name)
+    _apply_precision(transcriber, precision)
+    _sync_cuda()
+    load_seconds = time.perf_counter() - started
+
+    # Warm generation kernels separately from model loading and measured samples.
+    _sync_cuda()
+    started = time.perf_counter()
+    transcriber.warmup(seconds=1.0, all_buckets=True)
+    _sync_cuda()
+    warmup_seconds = time.perf_counter() - started
+
+    sample_results = []
+    for sample in manifest.get("samples", []):
+        audio_path = sample["audio"]
+        if not os.path.isabs(audio_path):
+            audio_path = os.path.join(manifest_dir, audio_path)
+        audio, audio_seconds, source_rate = load_audio(audio_path)
+        timings = []
+        transcripts = []
+        for _run in range(runs):
+            _sync_cuda()
+            started = time.perf_counter()
+            transcript = transcriber.transcribe(audio, language="en")
+            _sync_cuda()
+            timings.append(time.perf_counter() - started)
+            transcripts.append(transcript)
+        consensus = collections.Counter(transcripts).most_common(1)[0][0]
+        median_seconds = statistics.median(timings)
+        result = {
+            "id": sample["id"],
+            "audio": os.path.relpath(audio_path, manifest_dir),
+            "audio_seconds": audio_seconds,
+            "source_sample_rate": source_rate,
+            "runs": runs,
+            "transcript": consensus,
+            "transcript_variants": dict(collections.Counter(transcripts)),
+            "inference_seconds": {
+                "min": min(timings),
+                "median": median_seconds,
+                "p95": _percentile(timings, 0.95),
+                "all": timings,
+            },
+            "realtime_factor": median_seconds / audio_seconds,
+            "realtime_speedup": audio_seconds / median_seconds,
+            "estimated_release_to_paste_seconds": (
+                app.POST_ROLL_SEC + median_seconds + app.PASTE_DELAY_SEC
+            ),
+            "estimated_adaptive_release_to_paste_seconds": (
+                app.POST_ROLL_MIN_SEC + median_seconds + app.PASTE_DELAY_SEC
+            ),
+            "reference_reviewed": bool(sample.get("reference_reviewed", False)),
+        }
+        reference = sample.get("reference", "")
+        if reference and result["reference_reviewed"]:
+            result["reference"] = reference
+            result["accuracy"] = accuracy_metrics(reference, consensus)
+        else:
+            result["accuracy"] = None
+            result["accuracy_note"] = "Reference transcript requires human review."
+        sample_results.append(result)
+
+    reviewed = [item for item in sample_results if item["accuracy"] is not None]
+    total_words = sum(item["accuracy"]["reference_words"] for item in reviewed)
+    total_word_errors = sum(item["accuracy"]["word_errors"] for item in reviewed)
+    model_dtype = str(getattr(transcriber.model, "dtype", "unknown"))
+    cuda_allocated_mib = None
+    try:
+        import torch
+        if torch.cuda.is_available():
+            cuda_allocated_mib = torch.cuda.memory_allocated() / 1024 / 1024
+    except Exception:
+        pass
+    return {
+        "benchmark_version": 1,
+        "created_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "model": model_name,
+        "precision": precision,
+        "model_dtype": model_dtype,
+        "cuda_allocated_mib": cuda_allocated_mib,
+        "environment": _environment(),
+        "load_seconds": load_seconds,
+        "warmup_seconds": warmup_seconds,
+        "sample_count": len(sample_results),
+        "reviewed_sample_count": len(reviewed),
+        "aggregate_wer": total_word_errors / total_words if total_words else None,
+        "samples": sample_results,
+    }
+
+
+def _print_summary(result):
+    print("Model: %s | precision: %s (%s)" %
+          (result["model"], result["precision"], result["model_dtype"]))
+    if result["cuda_allocated_mib"] is not None:
+        print("CUDA tensors: %.1f MiB" % result["cuda_allocated_mib"])
+    print("Load: %.3fs | warm-up: %.3fs" %
+          (result["load_seconds"], result["warmup_seconds"]))
+    for sample in result["samples"]:
+        timing = sample["inference_seconds"]
+        print("\n%s: %.3fs median (%.1fx realtime, adaptive/max release-to-paste %.3f/%.3fs)" % (
+            sample["id"], timing["median"], sample["realtime_speedup"],
+            sample["estimated_adaptive_release_to_paste_seconds"],
+            sample["estimated_release_to_paste_seconds"],
+        ))
+        print("  %s" % sample["transcript"])
+        if sample["accuracy"] is None:
+            print("  Accuracy: pending reviewed reference")
+        else:
+            print("  WER: %.2f%% | CER: %.2f%%" % (
+                sample["accuracy"]["wer"] * 100,
+                sample["accuracy"]["cer"] * 100,
+            ))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default=os.path.join("benchmarks", "manifest.json"))
+    parser.add_argument("--model")
+    parser.add_argument("--runs", type=int)
+    parser.add_argument(
+        "--precision", choices=("auto", "tf32", "fp16", "bf16"), default="auto")
+    parser.add_argument("--output", help="JSON output path")
+    args = parser.parse_args()
+    result = run_benchmark(
+        args.manifest, model_name=args.model, runs=args.runs, precision=args.precision)
+    _print_summary(result)
+    if args.output:
+        output_path = os.path.abspath(args.output)
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as handle:
+            json.dump(result, handle, indent=2, ensure_ascii=False)
+        print("\nSaved %s" % output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/windows/british.py
+++ b/windows/british.py
@@ -1,0 +1,154 @@
+"""British English spelling conversion (US -> GB word list).
+
+Applied after transcription when the 'british' setting is enabled.
+Inflexions are handled: realizes -> realises, colored -> coloured,
+neighbors -> neighbours, mom's -> mum's.
+"""
+
+import re
+
+BRITISH = {
+    # -ize -> -ise
+    "analyze": "analyse", "apologize": "apologise", "authorize": "authorise",
+    "categorize": "categorise", "characterize": "characterise",
+    "colonize": "colonise", "criticize": "criticise", "customize": "customise",
+    "dramatize": "dramatise", "economize": "economise",
+    "emphasize": "emphasise", "fertilize": "fertilise", "formalize": "formalise",
+    "generalize": "generalise", "hypnotize": "hypnotise",
+    "hypothesize": "hypothesise", "idealize": "idealise",
+    "immobilize": "immobilise", "industrialize": "industrialise",
+    "itemize": "itemise", "legalize": "legalise", "localize": "localise",
+    "maximize": "maximise", "mechanize": "mechanise", "memorize": "memorise",
+    "minimize": "minimise", "mobilize": "mobilise", "modernize": "modernise",
+    "monopolize": "monopolise", "moralize": "moralise",
+    "nationalize": "nationalise", "naturalize": "naturalise",
+    "neutralize": "neutralise", "normalize": "normalise",
+    "optimize": "optimise", "organize": "organise",
+    "personalize": "personalise", "polarize": "polarise",
+    "prioritize": "prioritise", "privatize": "privatise",
+    "publicize": "publicise", "rationalize": "rationalise",
+    "realize": "realise", "recognize": "recognise",
+    "reorganize": "reorganise", "revolutionize": "revolutionise",
+    "romanticize": "romanticise", "sanitize": "sanitise",
+    "sensitize": "sensitise", "socialize": "socialise",
+    "specialize": "specialise", "stabilize": "stabilise",
+    "standardize": "standardise", "sterilize": "sterilise",
+    "subsidize": "subsidise", "summarize": "summarise",
+    "sympathize": "sympathise", "symbolize": "symbolise",
+    "synthesize": "synthesise", "systematize": "systematise",
+    "tantalize": "tantalise", "terrorize": "terrorise",
+    "tranquilize": "tranquillise", "trivialize": "trivialise",
+    "urbanize": "urbanise", "utilize": "utilise", "vandalize": "vandalise",
+    "verbalize": "verbalise", "visualize": "visualise",
+    "vitalize": "vitalise", "scrutinize": "scrutinise",
+    "satirize": "satirise", "monopolize": "monopolise",
+    # -or -> -our
+    "armor": "armour", "armory": "armoury", "ardor": "ardour",
+    "behavior": "behaviour", "candor": "candour", "clangor": "clangour",
+    "color": "colour", "colorful": "colourful",
+    "demeanor": "demeanour", "endeavor": "endeavour", "favor": "favour",
+    "favorite": "favourite", "fervor": "fervour", "flavor": "flavour",
+    "glamor": "glamour", "harbor": "harbour", "honor": "honour",
+    "honorable": "honourable", "labor": "labour", "neighbor": "neighbour",
+    "neighborhood": "neighbourhood", "odor": "odour", "parlor": "parlour",
+    "rancor": "rancour", "rumor": "rumour", "savior": "saviour",
+    "savor": "savour", "splendor": "splendour", "succor": "succour",
+    "valor": "valour", "vigor": "vigour",
+    # -er -> -re
+    "caliber": "calibre", "center": "centre", "fiber": "fibre",
+    "liter": "litre", "luster": "lustre", "maneuver": "manoeuvre",
+    "meager": "meagre", "saber": "sabre", "scepter": "sceptre",
+    "sepulcher": "sepulchre", "somber": "sombre", "specter": "spectre",
+    "centimeter": "centimetre", "millimeter": "millimetre",
+    "kilometer": "kilometre", "milliliter": "millilitre",
+    # -og -> -ogue
+    "analog": "analogue", "catalog": "catalogue", "demagog": "demagogue",
+    "dialog": "dialogue", "epilog": "epilogue", "monolog": "monologue",
+    "pedagog": "pedagogue", "prolog": "prologue", "travelog": "travelogue",
+    # -se -> -ce
+    "defense": "defence", "offense": "offence", "pretense": "pretence",
+    # -l- / -ll-
+    "canceled": "cancelled", "canceling": "cancelling",
+    "counselor": "counsellor", "counseling": "counselling",
+    "dialed": "dialled", "dialing": "dialling",
+    "enroll": "enrol", "enrollment": "enrolment",
+    "fueled": "fuelled", "fueling": "fuelling",
+    "fulfill": "fulfil", "fulfillment": "fulfilment",
+    "installment": "instalment", "instill": "instil",
+    "jewelery": "jewellery", "jewelry": "jewellery",
+    "labeled": "labelled", "labeling": "labelling",
+    "leveling": "levelling", "marveling": "marvelling",
+    "marvelous": "marvellous", "modeled": "modelled", "modeling": "modelling",
+    "quarreled": "quarrelled", "quarreling": "quarrelling",
+    "signaled": "signalled", "signaling": "signalling",
+    "skillful": "skilful", "skilful": "skilful",
+    "shoveling": "shovelling", "totaled": "totalled", "totaling": "totalling",
+    "traveled": "travelled", "traveler": "traveller", "traveling": "travelling",
+    "willful": "wilful", "woolen": "woollen", "worshiped": "worshipped",
+    "worshiping": "worshipping", "worshipper": "worshipper",
+    # medical / academic ae- oe-
+    "anemia": "anaemia", "anesthesia": "anaesthesia", "anesthetic": "anaesthetic",
+    "ameba": "amoeba", "archeology": "archaeology",
+    "diarrhea": "diarrhoea", "edema": "oedema",
+    "encyclopedia": "encyclopaedia", "esophagus": "oesophagus",
+    "estrogen": "oestrogen", "etiology": "aetiology", "fetus": "foetus",
+    "gynecology": "gynaecology", "gynecologist": "gynaecologist",
+    "hemorrhage": "haemorrhage", "leukemia": "leukaemia",
+    "orthopedic": "orthopaedic", "pediatric": "paediatric",
+    "pediatrician": "paediatrician", "paleontology": "palaeontology",
+    # other common pairs
+    "airplane": "aeroplane", "aluminum": "aluminium", "artifact": "artefact",
+    "cesium": "caesium", "cozy": "cosy", "curb": "kerb", "disk": "disc",
+    "donut": "doughnut", "gray": "grey", "judgment": "judgement",
+    "acknowledgment": "acknowledgement", "abridgment": "abridgement",
+    "math": "maths", "mold": "mould", "molt": "moult", "mom": "mum",
+    "mommy": "mummy", "moustache": "moustache", "mustache": "moustache",
+    "pajamas": "pyjamas", "plow": "plough", "skeptic": "sceptic",
+    "skeptical": "sceptical", "skepticism": "scepticism",
+    "smolder": "smoulder", "sulfur": "sulphur", "tire": "tyre",
+}
+
+_TOKEN_RE = re.compile(r"[A-Za-z']+")
+
+
+def to_british(text):
+    def convert(match):
+        token = match.group(0)
+        lower = token.lower()
+        repl = BRITISH.get(lower)
+        if repl is None and lower.endswith("'s"):
+            repl = BRITISH.get(lower[:-2])
+            if repl is not None:
+                repl += "'s"
+        if repl is None:
+            repl = _inflect(lower)
+        if repl is None:
+            return token
+        if token.isupper():
+            return repl.upper()
+        if token[:1].isupper():
+            return repl[:1].upper() + repl[1:]
+        return repl
+
+    return _TOKEN_RE.sub(convert, text)
+
+
+def _inflect(lower):
+    if lower.endswith("izing"):
+        base = BRITISH.get(lower[:-3] + "e")
+        if base:
+            return base + "ing"
+    if lower.endswith("ized"):
+        base = BRITISH.get(lower[:-2])
+        if base:
+            return base + "d"
+    if lower.endswith("izes"):
+        base = BRITISH.get(lower[:-2])
+        if base:
+            return base + "s"
+    for suffix in ("es", "s", "ed", "ing", "er", "est", "ly"):
+        if lower.endswith(suffix):
+            base = BRITISH.get(lower[:-len(suffix)])
+            if base:
+                return base + suffix
+    return None

--- a/windows/config.py
+++ b/windows/config.py
@@ -1,0 +1,71 @@
+"""Settings persistence for Presspeech for Windows."""
+
+import json
+import os
+
+APP_NAME = "Presspeech"
+CONFIG_DIR = os.path.join(os.environ.get("APPDATA", os.path.expanduser("~")), APP_NAME)
+CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
+
+DEFAULTS = {
+    "hotkey": "right alt",
+    "trigger": "hold",
+    "input_device": "auto",
+    "model": "parakeet-tdt-0.6b-v3",
+    "precision": "fp16",
+    "suffix": "space",
+    "remove_fillers": True,
+    "british": True,
+    "audio_cues": True,
+    "mute_playback_while_recording": True,
+    "visual_indicator": True,
+    "dictionary": [],
+    "autostart": False,
+    "capture_next_benchmark": False,
+    "capture_benchmark_remaining": 0,
+    "capture_benchmark_session": "",
+    "capture_benchmark_index": 1,
+    "gpu_idle_unload_sec": 0,
+}
+
+HOTKEYS = [
+    "right alt", "right ctrl", "right shift", "right win",
+    "left alt", "left ctrl",
+    "f8", "f9", "f10", "f11", "f12",
+]
+
+MODELS = [
+    "nemotron-speech-streaming-en-0.6b",
+    "parakeet-tdt-0.6b-v3",
+    "turbo",
+    "small.en",
+    "medium.en",
+    "base.en",
+]
+
+MODEL_LABELS = {
+    "nemotron-speech-streaming-en-0.6b": "Nemotron English 0.6B (GPU \u00b7 accurate + fast)",
+    "parakeet-tdt-0.6b-v3": "Parakeet TDT v3 (GPU \u00b7 best)",
+    "turbo": "Whisper turbo (GPU \u00b7 fast)",
+    "small.en": "Whisper small.en",
+    "medium.en": "Whisper medium.en",
+    "base.en": "Whisper base.en (CPU \u00b7 fastest)",
+}
+
+SUFFIXES = {"space": " ", "newline": "\n", "none": ""}
+
+
+def load():
+    settings = dict(DEFAULTS)
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+            settings.update(json.load(fh))
+    except (OSError, ValueError):
+        pass
+    return settings
+
+
+def save(settings):
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    with open(CONFIG_PATH, "w", encoding="utf-8") as fh:
+        json.dump(settings, fh, indent=2, ensure_ascii=False)

--- a/windows/engine.py
+++ b/windows/engine.py
@@ -1,0 +1,301 @@
+"""Transcription engines for Presspeech for Windows.
+
+Backends:
+
+- "parakeet-tdt-0.6b-v3" -> NVIDIA Parakeet-TDT-0.6B-v3 via HuggingFace
+  Transformers, runs on CUDA when available. Cutting-edge accuracy, automatic
+  punctuation and capitalization, 25 European languages. Same model family
+  used by Presspeech on macOS.
+- anything else -> faster-whisper (CTranslate2) model name, CUDA when
+  available, CPU otherwise.
+"""
+
+import gc
+import threading
+import time
+
+PARAKEET_MODEL = "nvidia/parakeet-tdt-0.6b-v3"
+NEMOTRON_MODEL = "nvidia/nemotron-speech-streaming-en-0.6b"
+MOONSHINE_MODEL = "UsefulSensors/moonshine-streaming-medium"
+
+NEMOTRON_NAME = "nemotron-speech-streaming-en-0.6b"
+MOONSHINE_NAME = "moonshine-streaming-medium"
+
+# Stable feature shapes avoid a roughly one-second CUDA/cuDNN setup cost for
+# every previously unseen recording length. The attention mask ensures padded
+# audio is ignored, so this does not change the decoded speech.
+PARAKEET_BUCKET_SECONDS = (15, 30, 60)
+
+
+def is_parakeet(model_name):
+    return model_name == "parakeet-tdt-0.6b-v3"
+
+
+def is_nemotron(model_name):
+    return model_name == NEMOTRON_NAME
+
+
+def is_moonshine(model_name):
+    return model_name == MOONSHINE_NAME
+
+
+def _configure_parakeet_processor(processor):
+    """Avoid repeatedly inferring the known decoder type from the full vocabulary."""
+    processor.decoder_type = "tdt"
+    return processor
+
+
+def _parakeet_dtype(torch_module, device, precision):
+    if device == "cuda" and precision == "fp16":
+        return torch_module.float16
+    if (device == "cuda" and precision == "bf16"
+            and torch_module.cuda.is_bf16_supported()):
+        return torch_module.bfloat16
+    return "auto"
+
+
+def _parakeet_bucket_seconds(audio_seconds):
+    for bucket in PARAKEET_BUCKET_SECONDS:
+        if audio_seconds <= bucket:
+            return bucket
+    # Very long dictation remains supported in 30-second increments. Its first
+    # uncommon shape may pay a one-time setup cost; normal speech uses a warmed
+    # bucket above.
+    return int((audio_seconds + 29) // 30 * 30)
+
+
+class Transcriber:
+    def __init__(self, precision="auto"):
+        self.lock = threading.Lock()
+        self.inference_lock = threading.Lock()
+        self.precision = precision
+        self.model = None
+        self.processor = None
+        self.backend = None
+        self.model_name = None
+        self.last_timing = {}
+
+    def loaded(self, model_name):
+        return self.model is not None and self.model_name == model_name
+
+    def load(self, model_name, notify=None):
+        with self.lock:
+            if self.loaded(model_name):
+                return
+            self._unload_locked()
+            if is_parakeet(model_name):
+                self._load_parakeet(notify)
+            elif is_nemotron(model_name):
+                self._load_nemotron(notify)
+            elif is_moonshine(model_name):
+                self._load_moonshine(notify)
+            else:
+                self._load_whisper(model_name, notify)
+            self.model_name = model_name
+            if notify is not None:
+                notify("Presspeech", "Model %s ready." % model_name)
+
+    def _load_parakeet(self, notify):
+        import torch
+        from transformers import AutoModelForTDT, AutoProcessor
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        if notify is not None:
+            notify("Presspeech",
+                   "Loading Parakeet-TDT v3 on %s (first run downloads ~2.5 GB)..." % device)
+        self.processor = _configure_parakeet_processor(
+            AutoProcessor.from_pretrained(PARAKEET_MODEL))
+        requested_dtype = _parakeet_dtype(torch, device, self.precision)
+        try:
+            self.model = AutoModelForTDT.from_pretrained(
+                PARAKEET_MODEL, dtype=requested_dtype)
+        except TypeError:
+            self.model = AutoModelForTDT.from_pretrained(PARAKEET_MODEL)
+        except Exception as exc:
+            if requested_dtype == "auto":
+                raise
+            if notify is not None:
+                notify("Presspeech", "Half-precision load failed; retrying FP32 (%s)"
+                       % str(exc)[:100])
+            self.model = AutoModelForTDT.from_pretrained(PARAKEET_MODEL, dtype="auto")
+        if device != "cpu":
+            self.model.to(device)
+        self.backend = "parakeet"
+        self._device = device
+
+    def _load_nemotron(self, notify):
+        import torch
+        from transformers import AutoModelForRNNT, AutoProcessor
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        if notify is not None:
+            notify("Presspeech", "Loading Nemotron English ASR on %s..." % device)
+        dtype = torch.float16 if device == "cuda" else torch.float32
+        self.processor = AutoProcessor.from_pretrained(NEMOTRON_MODEL)
+        self.model = AutoModelForRNNT.from_pretrained(
+            NEMOTRON_MODEL, dtype=dtype).to(device)
+        self.backend = "nemotron"
+        self._device = device
+
+    def _load_moonshine(self, notify):
+        import torch
+        from transformers import AutoProcessor, MoonshineStreamingForConditionalGeneration
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        if notify is not None:
+            notify("Presspeech", "Loading Moonshine Medium on %s..." % device)
+        dtype = torch.float16 if device == "cuda" else torch.float32
+        self.processor = AutoProcessor.from_pretrained(MOONSHINE_MODEL)
+        self.model = MoonshineStreamingForConditionalGeneration.from_pretrained(
+            MOONSHINE_MODEL, dtype=dtype).to(device)
+        self.backend = "moonshine"
+        self._device = device
+
+    def _load_whisper(self, model_name, notify):
+        from faster_whisper import WhisperModel
+        device = "cuda" if self._cuda_available() else "cpu"
+        compute = "float16" if device == "cuda" else "int8"
+        if notify is not None:
+            notify("Presspeech", "Loading Whisper %s on %s..." % (model_name, device))
+        self.model = WhisperModel(model_name, device=device, compute_type=compute)
+        self.backend = "whisper"
+        self._device = device
+
+    def _unload_locked(self):
+        if self.model is not None:
+            del self.model
+            self.model = None
+        self.processor = None
+        self.backend = None
+        self.model_name = None
+
+    def unload(self):
+        """Release the active model and its native resources while keeping the app alive."""
+        with self.inference_lock:
+            with self.lock:
+                backend = self.backend
+                self._unload_locked()
+            gc.collect()
+            if backend != "whisper":
+                try:
+                    import torch
+                    if torch.cuda.is_available():
+                        torch.cuda.empty_cache()
+                except Exception:
+                    pass
+
+    def transcribe(self, audio, language="en"):
+        requested_at = time.perf_counter()
+        with self.inference_lock:
+            acquired_at = time.perf_counter()
+            with self.lock:
+                model = self.model
+                processor = self.processor
+                backend = self.backend
+            if model is None or backend is None:
+                raise RuntimeError("no model loaded")
+            self._backend_timing = {}
+            if backend == "parakeet":
+                text = self._transcribe_parakeet(model, processor, audio)
+            elif backend == "nemotron":
+                text = self._transcribe_nemotron(model, processor, audio)
+            elif backend == "moonshine":
+                text = self._transcribe_moonshine(model, processor, audio)
+            else:
+                segments, _info = model.transcribe(
+                    audio, language=language, beam_size=1, vad_filter=False,
+                    without_timestamps=True,
+                )
+                text = "".join(seg.text for seg in segments).strip()
+            finished_at = time.perf_counter()
+            self.last_timing = {
+                "backend": backend,
+                "lock_wait": acquired_at - requested_at,
+                "inference": finished_at - acquired_at,
+                **self._backend_timing,
+            }
+            return text
+
+    def warmup(self, seconds=8.0, all_buckets=False):
+        """Run representative inference so the next real dictation is ready."""
+        import numpy as np
+        with self.lock:
+            backend = self.backend
+        if backend == "parakeet" and all_buckets:
+            for bucket in PARAKEET_BUCKET_SECONDS:
+                self.transcribe(
+                    np.zeros(bucket * 16000, dtype=np.float32), language="en")
+            return
+        self.transcribe(
+            np.zeros(max(1, int(seconds * 16000)), dtype=np.float32), language="en")
+
+    def _transcribe_parakeet(self, model, processor, audio):
+        import torch
+        bucket_seconds = _parakeet_bucket_seconds(len(audio) / 16000.0)
+        started = time.perf_counter()
+        inputs = processor(
+            audio,
+            sampling_rate=16000,
+            return_tensors="pt",
+            padding="max_length",
+            max_length=bucket_seconds * 16000,
+            truncation=True,
+            return_attention_mask=True,
+        )
+        processed = time.perf_counter()
+        inputs = {
+            k: (v.to(device=model.device, dtype=model.dtype)
+                if v.is_floating_point() else v.to(device=model.device))
+            for k, v in inputs.items()
+        }
+        transferred = time.perf_counter()
+        with torch.no_grad():
+            output = model.generate(**inputs, return_dict_in_generate=True)
+        generated = time.perf_counter()
+        decoded, _timestamps = processor.decode(
+            output.sequences, durations=output.durations, skip_special_tokens=True)
+        decoded_at = time.perf_counter()
+        self._backend_timing = {
+            "bucket_seconds": bucket_seconds,
+            "prepare": processed - started,
+            "transfer": transferred - processed,
+            "generate": generated - transferred,
+            "decode": decoded_at - generated,
+        }
+        if isinstance(decoded, (list, tuple)):
+            decoded = "".join(decoded)
+        return decoded.strip()
+
+    @staticmethod
+    def _transcribe_nemotron(model, processor, audio):
+        import torch
+        inputs = processor(
+            audio, sampling_rate=16000, return_tensors="pt"
+        ).to(model.device, dtype=model.dtype)
+        with torch.inference_mode():
+            output = model.generate(**inputs, return_dict_in_generate=True)
+        decoded = processor.decode(output.sequences, skip_special_tokens=True)
+        if isinstance(decoded, (list, tuple)):
+            decoded = "".join(decoded)
+        return decoded.strip()
+
+    @staticmethod
+    def _transcribe_moonshine(model, processor, audio):
+        import torch
+        inputs = processor(
+            audio, sampling_rate=16000, return_tensors="pt"
+        ).to(model.device, dtype=model.dtype)
+        # The model card recommends this audio-relative ceiling to prevent
+        # autoregressive hallucination loops on short or noisy recordings.
+        seq_lens = inputs.attention_mask.sum(dim=-1)
+        factor = 6.5 / processor.feature_extractor.sampling_rate
+        max_length = max(8, int((seq_lens * factor).max().item()))
+        with torch.inference_mode():
+            output = model.generate(**inputs, max_length=max_length)
+        decoded = processor.decode(output[0], skip_special_tokens=True)
+        return decoded.strip()
+
+    @staticmethod
+    def _cuda_available():
+        try:
+            import torch
+            return torch.cuda.is_available()
+        except Exception:
+            return False

--- a/windows/requirements.txt
+++ b/windows/requirements.txt
@@ -1,0 +1,14 @@
+faster-whisper>=1.0.0
+sounddevice>=0.4.6
+pynput>=1.7.6
+pystray>=0.19.5
+Pillow>=10.0.0
+pyperclip>=1.8.2
+pycaw==20251023
+numpy>=1.26.0
+soundfile>=0.12.1
+transformers>=5.14.1,<6
+sentencepiece>=0.2.0
+
+# PyTorch with CUDA 12 (for Parakeet-TDT on the GPU). Install with:
+#   pip install torch --index-url https://download.pytorch.org/whl/cu126

--- a/windows/run.bat
+++ b/windows/run.bat
@@ -1,0 +1,3 @@
+@echo off
+cd /d "%~dp0"
+start "" "%~dp0\.venv\Scripts\pythonw.exe" "%~dp0\app.py"

--- a/windows/tests/test_app.py
+++ b/windows/tests/test_app.py
@@ -1,0 +1,246 @@
+import unittest
+from unittest import mock
+
+import app
+import config
+
+
+DEVICES = [
+    {"name": "Microsoft Sound Mapper - Input", "hostapi": 0,
+     "max_input_channels": 2},
+    {"name": "Microphone (Yeti Nano)", "hostapi": 0,
+     "max_input_channels": 2},
+    {"name": "Microphone (Yeti Nano)", "hostapi": 1,
+     "max_input_channels": 2},
+    {"name": "Stereo Mix", "hostapi": 2, "max_input_channels": 2},
+    {"name": "Microphone (Yeti Nano)", "hostapi": 2,
+     "max_input_channels": 2},
+    {"name": "Headset Microphone (HyperX 7.1 Audio)", "hostapi": 0,
+     "max_input_channels": 2},
+]
+
+HOST_APIS = [
+    {"name": "MME"},
+    {"name": "Windows WASAPI"},
+    {"name": "Windows WDM-KS"},
+]
+
+
+class InputSelectionTests(unittest.TestCase):
+    def make_app(self, selected="auto"):
+        instance = app.PresspeechApp.__new__(app.PresspeechApp)
+        instance.input_device = None
+        instance.settings = {"input_device": selected}
+        return instance
+
+    def sounddevice_mocks(self):
+        return (
+            mock.patch.object(app.sd, "query_devices", return_value=DEVICES),
+            mock.patch.object(app.sd, "query_hostapis", return_value=HOST_APIS),
+            mock.patch.object(app.sd, "check_input_settings", return_value=None),
+            mock.patch.object(app.PresspeechApp, "_probe_input", return_value=True),
+            mock.patch.object(app.PresspeechApp, "_log"),
+        )
+
+    def test_automatic_prefers_windows_sound_mapper_at_16khz(self):
+        instance = self.make_app()
+        patches = self.sounddevice_mocks()
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            self.assertEqual(instance._get_input_device(), (0, 16000))
+
+    def test_configured_device_uses_stable_host_and_name_selector(self):
+        selector = app.PresspeechApp._device_selector(DEVICES[1], "MME")
+        instance = self.make_app(selector)
+        patches = self.sounddevice_mocks()
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            self.assertEqual(instance._get_input_device(), (1, 16000))
+
+    def test_picker_excludes_stereo_mix_wdm_ks_and_hyperx(self):
+        instance = self.make_app()
+        with mock.patch.object(app.sd, "query_devices", return_value=DEVICES), \
+                mock.patch.object(app.sd, "query_hostapis", return_value=HOST_APIS):
+            options = instance.input_device_options()
+        labels = [label for label, _selector in options]
+        self.assertFalse(any("Stereo Mix" in label for label in labels))
+        self.assertFalse(any("WDM-KS" in label for label in labels))
+        self.assertFalse(any("HyperX" in label for label in labels))
+
+    def test_configured_device_never_falls_back_to_another_microphone(self):
+        instance = self.make_app("MME::Missing microphone")
+        patches = self.sounddevice_mocks()
+        with patches[0], patches[1], patches[2], patches[3] as probe, patches[4]:
+            self.assertIsNone(instance._get_input_device())
+        probe.assert_not_called()
+
+
+class TextRegressionTests(unittest.TestCase):
+    def test_dictionary_rules_match_whole_phrases_only(self):
+        instance = app.PresspeechApp.__new__(app.PresspeechApp)
+        instance.settings = {
+            "dictionary": [["parake", "Parakeet"],
+                           ["bass model", "base model"]],
+            "remove_fillers": False,
+            "british": False,
+            "suffix": "none",
+        }
+        self.assertEqual(
+            instance._apply_text("Parake beats the bass model."),
+            "Parakeet beats the base model.")
+        self.assertEqual(
+            instance._apply_text("Parakeet is already correct."),
+            "Parakeet is already correct.")
+
+    def test_filler_removal_keeps_well(self):
+        self.assertEqual(app.FILLER_RE.sub("", "It works well."), "It works well.")
+        self.assertEqual(app.FILLER_RE.sub("", "Um, it works."), ", it works.")
+
+    def test_input_device_default_is_automatic(self):
+        self.assertEqual(config.DEFAULTS["input_device"], "auto")
+
+    def test_default_precision_is_fp16(self):
+        self.assertEqual(config.DEFAULTS["precision"], "fp16")
+
+    def test_paste_delay_is_small_but_nonzero(self):
+        self.assertGreater(app.PASTE_DELAY_SEC, 0)
+        self.assertLessEqual(app.PASTE_DELAY_SEC, 0.01)
+
+    def test_paste_routes_for_remote_clients(self):
+        self.assertEqual(app._paste_route("Moonlight.exe"), "moonlight")
+        self.assertEqual(app._paste_route("mstsc.exe"), "rdp")
+        self.assertEqual(app._paste_route("msrdc.exe"), "rdp")
+        self.assertEqual(app._paste_route("notepad.exe"), "local")
+
+    def test_recording_remembers_foreground_paste_target(self):
+        instance = app.PresspeechApp.__new__(app.PresspeechApp)
+        instance.lock = __import__("threading").Lock()
+        instance.recording = False
+        instance.buffer = []
+        instance._rec_epoch = 0
+        instance._model_idle_epoch = 0
+        instance._play_cue = mock.Mock()
+        instance._wake_model_if_idle = mock.Mock()
+        with mock.patch.object(app, "_foreground_process_name",
+                               return_value="moonlight.exe"), \
+                mock.patch.object(app.threading, "Thread"), \
+                mock.patch.object(app.PresspeechApp, "_log"):
+            instance.start_recording()
+        self.assertEqual(instance._recording_target_process, "moonlight.exe")
+
+    def test_audio_cues_default_on(self):
+        self.assertTrue(config.DEFAULTS["audio_cues"])
+
+    def test_playback_muting_defaults_on(self):
+        self.assertTrue(config.DEFAULTS["mute_playback_while_recording"])
+
+    def test_visual_indicator_defaults_on(self):
+        self.assertTrue(config.DEFAULTS["visual_indicator"])
+
+    def test_visual_indicator_routes_states_without_stealing_app_logic(self):
+        instance = app.PresspeechApp.__new__(app.PresspeechApp)
+        instance.settings = {"visual_indicator": True}
+        instance.indicator = mock.Mock()
+        instance._set_indicator("listening")
+        instance._set_indicator("transcribing")
+        instance._set_indicator(None)
+        self.assertEqual(
+            instance.indicator.mock_calls,
+            [mock.call.show("listening"), mock.call.show("transcribing"),
+             mock.call.hide()],
+        )
+
+    def test_playback_mute_restores_the_prior_endpoint_state(self):
+        instance = app.PresspeechApp.__new__(app.PresspeechApp)
+        instance.settings = {"mute_playback_while_recording": True}
+        instance.recording = True
+        instance.lock = __import__("threading").Lock()
+        instance._playback_mute_lock = __import__("threading").Lock()
+        instance._playback_restore = None
+        instance._log = mock.Mock()
+        with mock.patch.object(app, "_mute_default_playback",
+                               return_value=("endpoint-id", True)) as mute, \
+                mock.patch.object(app, "_restore_playback_mute",
+                                  return_value=True) as restore:
+            instance._mute_playback_for_recording()
+            instance.recording = False
+            instance._restore_playback_after_recording()
+        mute.assert_called_once_with()
+        restore.assert_called_once_with("endpoint-id", True)
+        self.assertIsNone(instance._playback_restore)
+
+    def test_start_cue_finishes_before_playback_mutes_and_mic_opens(self):
+        instance = app.PresspeechApp.__new__(app.PresspeechApp)
+        instance.settings = {"audio_cues": True}
+        calls = mock.Mock()
+        instance._play_cue_worker = calls.cue
+        instance._mute_playback_for_recording = calls.mute
+        instance._open_mic_worker = calls.open_mic
+        instance._start_audio_worker()
+        self.assertEqual(
+            calls.mock_calls,
+            [mock.call.cue("start"), mock.call.mute(), mock.call.open_mic()],
+        )
+
+    def test_audio_cues_are_valid_and_distinct_wav_data(self):
+        self.assertTrue(app.CUE_SOUNDS["start"].startswith(b"RIFF"))
+        self.assertTrue(app.CUE_SOUNDS["stop"].startswith(b"RIFF"))
+        self.assertNotEqual(app.CUE_SOUNDS["start"], app.CUE_SOUNDS["stop"])
+
+    def test_audio_cue_dispatch_does_not_block_caller(self):
+        instance = app.PresspeechApp.__new__(app.PresspeechApp)
+        instance.settings = {"audio_cues": True}
+        with mock.patch.object(app.threading, "Thread") as thread:
+            instance._play_cue("start")
+        thread.assert_called_once_with(
+            target=instance._play_cue_worker, args=("start",), daemon=True)
+        thread.return_value.start.assert_called_once_with()
+
+
+class PostRollTests(unittest.TestCase):
+    def make_app(self, value, peak=0.1, rate=16000):
+        instance = app.PresspeechApp.__new__(app.PresspeechApp)
+        instance.lock = __import__("threading").Lock()
+        instance.buffer = [__import__("numpy").full(
+            (int(rate * app.POST_ROLL_TAIL_SEC), 1), value, dtype="float32")]
+        instance.input_device = (0, rate)
+        instance._peak_rms = peak
+        return instance
+
+    def test_quiet_tail_is_silence(self):
+        instance = self.make_app(0.001)
+        rms, threshold = instance._post_roll_tail()
+        self.assertLessEqual(rms, threshold)
+
+    def test_voiced_tail_keeps_recording(self):
+        instance = self.make_app(0.03)
+        rms, threshold = instance._post_roll_tail()
+        self.assertGreater(rms, threshold)
+
+    def test_maximum_window_stops_even_with_voiced_tail(self):
+        instance = self.make_app(0.03)
+        instance._rec_epoch = 7
+        instance.stop_recording = mock.Mock()
+        with mock.patch.object(app.time, "perf_counter", return_value=10.5), \
+                mock.patch.object(app.PresspeechApp, "_log"):
+            instance._finish_after_roll(7, 10.0)
+        instance.stop_recording.assert_called_once_with()
+
+
+class StartupTests(unittest.TestCase):
+    def test_startup_worker_preloads_configured_model(self):
+        instance = app.PresspeechApp.__new__(app.PresspeechApp)
+        instance.settings = {"model": "parakeet-tdt-0.6b-v3"}
+        instance.transcriber = mock.Mock()
+        instance.notify = mock.Mock()
+        with mock.patch.object(app.PresspeechApp, "_log") as log:
+            instance._preload_model_worker()
+        instance.transcriber.load.assert_called_once_with(
+            "parakeet-tdt-0.6b-v3", notify=instance.notify)
+        instance.transcriber.warmup.assert_called_once_with(
+            seconds=app.MODEL_WARMUP_SEC, all_buckets=True)
+        ready_logs = [call.args[0] for call in log.call_args_list
+                      if call.args and call.args[0].startswith("model ready:")]
+        self.assertEqual(len(ready_logs), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/windows/tests/test_benchmark.py
+++ b/windows/tests/test_benchmark.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest import mock
+
+import benchmark
+
+
+class MetricTests(unittest.TestCase):
+    def test_identical_text_has_zero_error(self):
+        metrics = benchmark.accuracy_metrics("It works well.", "It works well.")
+        self.assertEqual(metrics["wer"], 0)
+        self.assertEqual(metrics["cer"], 0)
+        self.assertTrue(metrics["exact_match"])
+
+    def test_word_error_rate_ignores_case_and_punctuation(self):
+        metrics = benchmark.accuracy_metrics("Hello, colour!", "hello color")
+        self.assertEqual(metrics["word_errors"], 1)
+        self.assertEqual(metrics["reference_words"], 2)
+        self.assertEqual(metrics["wer"], 0.5)
+
+    def test_edit_distance_handles_insert_delete_and_replace(self):
+        self.assertEqual(benchmark.edit_distance(["a", "b"], ["a", "x", "b"]), 1)
+        self.assertEqual(benchmark.edit_distance(["a", "b"], ["a"]), 1)
+        self.assertEqual(benchmark.edit_distance(["a"], ["b"]), 1)
+
+    def test_percentile_uses_observed_upper_value(self):
+        self.assertEqual(benchmark._percentile([0.1, 0.2, 0.3, 0.4], 0.95), 0.4)
+
+    def test_auto_precision_does_not_mutate_model(self):
+        transcriber = mock.Mock()
+        benchmark._apply_precision(transcriber, "auto")
+        transcriber.model.to.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/windows/tests/test_engine.py
+++ b/windows/tests/test_engine.py
@@ -1,0 +1,48 @@
+import types
+import unittest
+from unittest import mock
+
+import engine
+
+
+class ParakeetConfigurationTests(unittest.TestCase):
+    def test_candidate_model_names_use_their_transformers_backends(self):
+        self.assertTrue(engine.is_nemotron("nemotron-speech-streaming-en-0.6b"))
+        self.assertTrue(engine.is_moonshine("moonshine-streaming-medium"))
+        self.assertFalse(engine.is_nemotron("small.en"))
+
+    def test_parakeet_uses_smallest_pre_warmed_audio_bucket(self):
+        self.assertEqual(engine._parakeet_bucket_seconds(1.0), 15)
+        self.assertEqual(engine._parakeet_bucket_seconds(15.0), 15)
+        self.assertEqual(engine._parakeet_bucket_seconds(15.01), 30)
+        self.assertEqual(engine._parakeet_bucket_seconds(30.01), 60)
+        self.assertEqual(engine._parakeet_bucket_seconds(61.0), 90)
+
+    def test_processor_is_explicitly_configured_for_tdt(self):
+        processor = types.SimpleNamespace(decoder_type=None)
+        returned = engine._configure_parakeet_processor(processor)
+        self.assertIs(returned, processor)
+        self.assertEqual(processor.decoder_type, "tdt")
+
+    def test_fp16_is_selected_only_for_cuda(self):
+        torch = types.SimpleNamespace(float16="fp16", bfloat16="bf16")
+        torch.cuda = mock.Mock()
+        torch.cuda.is_bf16_supported.return_value = True
+        self.assertEqual(engine._parakeet_dtype(torch, "cuda", "fp16"), "fp16")
+        self.assertEqual(engine._parakeet_dtype(torch, "cpu", "fp16"), "auto")
+
+    def test_unload_clears_active_model(self):
+        transcriber = engine.Transcriber()
+        transcriber.model = object()
+        transcriber.processor = object()
+        transcriber.backend = "whisper"
+        transcriber.model_name = "base.en"
+        transcriber.unload()
+        self.assertIsNone(transcriber.model)
+        self.assertIsNone(transcriber.processor)
+        self.assertIsNone(transcriber.backend)
+        self.assertIsNone(transcriber.model_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/windows/ui.py
+++ b/windows/ui.py
@@ -1,0 +1,390 @@
+"""Tkinter windows: settings, scratchpad, and a focus-safe status overlay."""
+
+import ctypes
+import queue
+import threading
+import tkinter as tk
+from tkinter import ttk
+
+import config as cfg
+
+
+class DictationIndicator:
+    """Small click-through overlay driven safely from any application thread."""
+
+    _STATES = {
+        "listening": ("Listening\u2026", "#ff5a5f"),
+        "transcribing": ("Transcribing\u2026", "#ffb340"),
+    }
+
+    def __init__(self):
+        self._commands = queue.Queue()
+        self._thread = None
+        self._thread_lock = threading.Lock()
+        self._closed = False
+
+    def show(self, state):
+        if state not in self._STATES or self._closed:
+            return
+        self._ensure_thread()
+        self._commands.put(state)
+
+    def hide(self):
+        if self._thread is not None and not self._closed:
+            self._commands.put("hide")
+
+    def close(self):
+        self._closed = True
+        if self._thread is not None:
+            self._commands.put("close")
+
+    def _ensure_thread(self):
+        with self._thread_lock:
+            if self._thread is None:
+                self._thread = threading.Thread(
+                    target=self._run, name="presspeech-indicator", daemon=True)
+                self._thread.start()
+
+    @staticmethod
+    def _work_area():
+        """Return the work area of the monitor containing the active window."""
+        user32 = ctypes.windll.user32
+        user32.GetForegroundWindow.restype = ctypes.c_void_p
+        user32.MonitorFromWindow.argtypes = [ctypes.c_void_p, ctypes.c_ulong]
+        user32.MonitorFromWindow.restype = ctypes.c_void_p
+
+        class RECT(ctypes.Structure):
+            _fields_ = [("left", ctypes.c_long), ("top", ctypes.c_long),
+                        ("right", ctypes.c_long), ("bottom", ctypes.c_long)]
+
+        class MONITORINFO(ctypes.Structure):
+            _fields_ = [("cbSize", ctypes.c_ulong), ("rcMonitor", RECT),
+                        ("rcWork", RECT), ("dwFlags", ctypes.c_ulong)]
+
+        hwnd = user32.GetForegroundWindow()
+        monitor = user32.MonitorFromWindow(hwnd, 2)  # MONITOR_DEFAULTTONEAREST
+        info = MONITORINFO()
+        info.cbSize = ctypes.sizeof(info)
+        if monitor and user32.GetMonitorInfoW(monitor, ctypes.byref(info)):
+            return info.rcWork
+        return RECT(0, 0, user32.GetSystemMetrics(0), user32.GetSystemMetrics(1))
+
+    def _run(self):
+        try:
+            root = tk.Tk()
+            root.withdraw()
+            root.title("Presspeech Indicator")
+            root.overrideredirect(True)
+            root.configure(bg="#202124")
+            root.attributes("-topmost", True)
+            root.attributes("-alpha", 0.94)
+
+            frame = tk.Frame(root, bg="#202124", padx=12, pady=7)
+            frame.pack(fill="both", expand=True)
+            dot = tk.Label(frame, text="\u25cf", bg="#202124", fg="#ff5a5f",
+                           font=("Segoe UI", 11))
+            dot.pack(side="left")
+            label = tk.Label(frame, text="Listening\u2026", bg="#202124", fg="#ffffff",
+                             font=("Segoe UI", 10, "bold"), padx=7)
+            label.pack(side="left")
+            root.update_idletasks()
+
+            user32 = ctypes.windll.user32
+            user32.GetParent.argtypes = [ctypes.c_void_p]
+            user32.GetParent.restype = ctypes.c_void_p
+            client_hwnd = root.winfo_id()
+            hwnd = user32.GetParent(client_hwnd) or client_hwnd
+            get_window_long = user32.GetWindowLongPtrW
+            set_window_long = user32.SetWindowLongPtrW
+            get_window_long.argtypes = [ctypes.c_void_p, ctypes.c_int]
+            set_window_long.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_ssize_t]
+            get_window_long.restype = ctypes.c_ssize_t
+            set_window_long.restype = ctypes.c_ssize_t
+            ex_style = get_window_long(hwnd, -20)  # GWL_EXSTYLE
+            ex_style |= 0x00000080  # WS_EX_TOOLWINDOW
+            ex_style |= 0x00000020  # WS_EX_TRANSPARENT (click-through)
+            ex_style |= 0x08000000  # WS_EX_NOACTIVATE
+            set_window_long(hwnd, -20, ex_style)
+            user32.ShowWindow.argtypes = [ctypes.c_void_p, ctypes.c_int]
+            user32.SetWindowPos.argtypes = [
+                ctypes.c_void_p, ctypes.c_void_p,
+                ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+                ctypes.c_uint,
+            ]
+
+            width, height = 154, 38
+
+            def apply_command(command):
+                if command == "close":
+                    root.destroy()
+                    return False
+                if command == "hide":
+                    user32.ShowWindow(hwnd, 0)  # SW_HIDE
+                    return True
+                text, colour = self._STATES[command]
+                label.configure(text=text)
+                dot.configure(fg=colour)
+                area = self._work_area()
+                x = area.left + ((area.right - area.left - width) // 2)
+                y = area.bottom - height - 42
+                user32.SetWindowPos(
+                    hwnd, ctypes.c_void_p(-1), x, y, width, height,
+                    0x0010 | 0x0040,  # SWP_NOACTIVATE | SWP_SHOWWINDOW
+                )
+                return True
+
+            def poll():
+                command = None
+                try:
+                    while True:
+                        command = self._commands.get_nowait()
+                except queue.Empty:
+                    pass
+                if command is not None and not apply_command(command):
+                    return
+                root.after(25, poll)
+
+            root.after(0, poll)
+            root.mainloop()
+        except Exception:
+            # Dictation must remain usable even if Windows refuses the overlay.
+            return
+
+
+class SettingsWindow:
+    def __init__(self, app):
+        self.app = app
+        self.root = None
+        threading.Thread(target=self._build, daemon=True).start()
+
+    def _build(self):
+        s = self.app.settings
+        root = tk.Tk()
+        self.root = root
+        root.title("Presspeech Settings")
+        root.resizable(False, False)
+        f = ttk.Frame(root, padding=12)
+        f.pack(fill="both", expand=True)
+
+        row = 0
+
+        ttk.Label(f, text="Dictation hotkey").grid(row=row, column=0, sticky="w", pady=2)
+        self.var_hotkey = ttk.Combobox(f, values=cfg.HOTKEYS, state="readonly", width=14)
+        self.var_hotkey.set(s["hotkey"])
+        self.var_hotkey.grid(row=row, column=1, sticky="w", padx=10, pady=2)
+        row += 1
+
+        ttk.Label(f, text="Trigger").grid(row=row, column=0, sticky="w", pady=2)
+        self.var_trigger = tk.StringVar(value=s["trigger"])
+        ttk.Radiobutton(f, text="Hold to talk", value="hold", variable=self.var_trigger).grid(
+            row=row, column=1, sticky="w", padx=10)
+        ttk.Radiobutton(f, text="Press to toggle", value="toggle", variable=self.var_trigger).grid(
+            row=row, column=2, sticky="w")
+        row += 1
+
+        ttk.Label(f, text="Microphone").grid(row=row, column=0, sticky="w", pady=2)
+        device_options = self.app.input_device_options()
+        self.device_values = {label: value for label, value in device_options}
+        selected_device = s.get("input_device", cfg.DEFAULTS["input_device"])
+        selected_label = next(
+            (label for label, value in device_options if value == selected_device),
+            device_options[0][0],
+        )
+        self.var_device = ttk.Combobox(
+            f, values=[label for label, _value in device_options],
+            state="readonly", width=46,
+        )
+        self.var_device.set(selected_label)
+        self.var_device.grid(row=row, column=1, columnspan=2, sticky="w", padx=10, pady=2)
+        row += 1
+
+        ttk.Label(f, text="Speech model").grid(row=row, column=0, sticky="w", pady=2)
+        self.var_model = ttk.Combobox(f, values=[cfg.MODEL_LABELS[m] for m in cfg.MODELS],
+                                      state="readonly", width=26)
+        self.var_model.set(cfg.MODEL_LABELS.get(s["model"], cfg.MODEL_LABELS[cfg.MODELS[0]]))
+        self.var_model.grid(row=row, column=1, sticky="w", padx=10, pady=2)
+        ttk.Label(f, text="GPU models need the NVIDIA runtime").grid(
+            row=row, column=2, sticky="w", foreground="#666")
+        row += 1
+
+        ttk.Label(f, text="After pasting").grid(row=row, column=0, sticky="w", pady=2)
+        self.var_suffix = ttk.Combobox(
+            f, values=["space", "newline", "none"], state="readonly", width=14)
+        self.var_suffix.set(s["suffix"])
+        self.var_suffix.grid(row=row, column=1, sticky="w", padx=10, pady=2)
+        row += 1
+
+        self.var_fillers = tk.BooleanVar(value=s["remove_fillers"])
+        ttk.Checkbutton(f, text="Remove filler words (um, uh, er\u2026)",
+                        variable=self.var_fillers).grid(row=row, column=0, columnspan=3,
+                                                        sticky="w", pady=2)
+        row += 1
+
+        self.var_british = tk.BooleanVar(value=s.get("british", True))
+        ttk.Checkbutton(f, text="British English spelling (color \u2192 colour)",
+                        variable=self.var_british).grid(row=row, column=0, columnspan=3,
+                                                        sticky="w", pady=2)
+        row += 1
+
+        self.var_audio_cues = tk.BooleanVar(value=s.get("audio_cues", True))
+        ttk.Checkbutton(f, text="Audio cues when dictation starts and stops",
+                        variable=self.var_audio_cues).grid(
+                            row=row, column=0, columnspan=3, sticky="w", pady=2)
+        row += 1
+
+        self.var_mute_playback = tk.BooleanVar(
+            value=s.get("mute_playback_while_recording", True))
+        ttk.Checkbutton(f, text="Mute speaker playback while dictating",
+                        variable=self.var_mute_playback).grid(
+                            row=row, column=0, columnspan=3, sticky="w", pady=2)
+        row += 1
+
+        self.var_visual_indicator = tk.BooleanVar(value=s.get("visual_indicator", True))
+        ttk.Checkbutton(f, text="Show listening and transcribing indicator",
+                        variable=self.var_visual_indicator).grid(
+                            row=row, column=0, columnspan=3, sticky="w", pady=2)
+        row += 1
+
+        self.var_autostart = tk.BooleanVar(value=s["autostart"])
+        ttk.Checkbutton(f, text="Start with Windows",
+                        variable=self.var_autostart).grid(row=row, column=0, columnspan=3,
+                                                          sticky="w", pady=2)
+        row += 1
+
+        ttk.Separator(f, orient="horizontal").grid(row=row, column=0, columnspan=3,
+                                                   sticky="ew", pady=8)
+        row += 1
+
+        ttk.Label(f, text="Dictionary (fix mishearings / spoken shortcuts):").grid(
+            row=row, column=0, columnspan=3, sticky="w")
+        row += 1
+
+        self.var_spoken = tk.StringVar()
+        self.var_replace = tk.StringVar()
+        ttk.Entry(f, textvariable=self.var_spoken, width=18).grid(
+            row=row, column=0, sticky="w", pady=2)
+        ttk.Label(f, text="\u2192").grid(row=row, column=1)
+        ttk.Entry(f, textvariable=self.var_replace, width=18).grid(
+            row=row, column=2, sticky="w", padx=10, pady=2)
+        row += 1
+
+        ttk.Button(f, text="Add rule", command=self._add_rule).grid(
+            row=row, column=0, sticky="w", pady=2)
+        ttk.Button(f, text="Remove selected", command=self._remove_rule).grid(
+            row=row, column=1, columnspan=2, sticky="w")
+        row += 1
+
+        self.listbox = tk.Listbox(f, width=52, height=6)
+        self.listbox.grid(row=row, column=0, columnspan=3, sticky="ew", pady=4)
+        for spoken, replacement in s["dictionary"]:
+            self.listbox.insert("end", "%s \u2192 %s" % (spoken, replacement))
+        row += 1
+
+        ttk.Separator(f, orient="horizontal").grid(row=row, column=0, columnspan=3,
+                                                   sticky="ew", pady=8)
+        row += 1
+
+        ttk.Button(f, text="Save", command=self._save).grid(row=row, column=0, sticky="w")
+        self.status = ttk.Label(f, text="", foreground="#666")
+        self.status.grid(row=row, column=1, columnspan=2, sticky="w", padx=10)
+
+        root.protocol("WM_DELETE_WINDOW", self._close)
+        root.mainloop()
+        self.root = None
+        self.app.settings_window = None
+
+    def _add_rule(self):
+        spoken = self.var_spoken.get().strip()
+        replacement = self.var_replace.get()
+        if not spoken:
+            return
+        self.listbox.insert("end", "%s \u2192 %s" % (spoken, replacement))
+        self.var_spoken.set("")
+        self.var_replace.set("")
+
+    def _remove_rule(self):
+        selection = self.listbox.curselection()
+        if selection:
+            self.listbox.delete(selection[0])
+
+    def _save(self):
+        s = self.app.settings
+        label_to_value = {v: k for k, v in cfg.MODEL_LABELS.items()}
+        s["hotkey"] = self.var_hotkey.get() or cfg.DEFAULTS["hotkey"]
+        s["trigger"] = self.var_trigger.get()
+        old_input_device = s.get("input_device", cfg.DEFAULTS["input_device"])
+        s["input_device"] = self.device_values.get(
+            self.var_device.get(), cfg.DEFAULTS["input_device"])
+        if s["input_device"] != old_input_device:
+            self.app.input_device = None
+        s["model"] = label_to_value.get(self.var_model.get(), cfg.DEFAULTS["model"])
+        s["suffix"] = self.var_suffix.get() or cfg.DEFAULTS["suffix"]
+        s["remove_fillers"] = bool(self.var_fillers.get())
+        s["british"] = bool(self.var_british.get())
+        s["audio_cues"] = bool(self.var_audio_cues.get())
+        s["mute_playback_while_recording"] = bool(self.var_mute_playback.get())
+        s["visual_indicator"] = bool(self.var_visual_indicator.get())
+        if not s["visual_indicator"]:
+            self.app._set_indicator(None)
+        s["autostart"] = bool(self.var_autostart.get())
+        rules = []
+        for line in self.listbox.get(0, "end"):
+            if "\u2192" in line:
+                spoken, replacement = line.split("\u2192", 1)
+                rules.append([spoken.strip(), replacement.strip()])
+        s["dictionary"] = rules
+        cfg.save(s)
+        self.app.apply_autostart()
+        self.status.config(text="Saved. Hotkey changes apply immediately.")
+
+    def _close(self):
+        try:
+            self.root.destroy()
+        except Exception:
+            pass
+
+
+class ScratchpadWindow:
+    def __init__(self, app):
+        self.app = app
+        self.root = None
+        threading.Thread(target=self._build, daemon=True).start()
+
+    def _build(self):
+        root = tk.Tk()
+        self.root = root
+        root.title("Presspeech - Try Dictation")
+        root.geometry("480x280")
+        self.text = tk.Text(root, wrap="word", font=("Segoe UI", 12))
+        self.text.pack(fill="both", expand=True, padx=8, pady=8)
+        self.btn = ttk.Button(root, text="Dictate (or use the hotkey)", command=self.toggle)
+        self.btn.pack(pady=(0, 8))
+        root.protocol("WM_DELETE_WINDOW", self._close)
+        root.mainloop()
+        self.root = None
+        self.app.scratchpad = None
+        self.app.paste_target = "paste"
+
+    def toggle(self):
+        if self.app.recording:
+            self.app.stop_recording()
+            self.btn.config(text="Dictate (or use the hotkey)")
+        else:
+            self.app.paste_target = "scratchpad"
+            self.app.start_recording()
+            self.btn.config(text="Stop")
+
+    def append_text(self, text):
+        def do():
+            self.text.insert("end", text)
+            self.text.see("end")
+        try:
+            self.root.after(0, do)
+        except Exception:
+            pass
+
+    def _close(self):
+        try:
+            self.root.destroy()
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary

- add the working Windows tray implementation under `windows/` while leaving the released macOS app isolated and unchanged
- use local NVIDIA Parakeet TDT v3 with startup preload/warmup, Whisper fallback, Right Alt hold-to-talk, microphone selection, British spelling, audio cues, playback muting, and a click-through state indicator
- include deterministic text/audio/device regression tests, local benchmark tooling, Windows setup documentation, and a path-filtered Windows CI workflow
- preserve privacy by excluding local audio/results/caches and logging only transcript length and timing rather than dictated text

## Why

The repository previously contained only the macOS implementation. This brings the tuned Windows app into the same project without introducing a shared runtime abstraction or changing the macOS release path.

## Verification

- `python -m unittest discover -s tests -v` — 33 passed
- Python source compilation passed
- `scripts/check-log-privacy.py --self-test` passed
- `scripts/check-log-privacy.py` passed
- `scripts/sync-docs.py --check` passed
- `git diff --check` passed

Model caches, virtual environments, logs, personal benchmark WAVs/results, and local configuration are not included.
