### PR TITLE
Report why a hotkey press produced no recording

### DIFF
--- a/swift/Sources/Presspeech/main.swift
+++ b/swift/Sources/Presspeech/main.swift
@@ -2760,6 +2760,16 @@ final class HotkeyListener {
     private var tap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
     private var transitionState = HotkeyTransitionState()
+    /// `tapCreate` succeeding proves only that the tap was installed, not
+    /// that events are reaching it — with Input Monitoring stale the tap
+    /// goes live and then stays silent forever, which is indistinguishable
+    /// in the log from "the user never pressed anything". Log the first
+    /// event that actually arrives so the two can be told apart.
+    private var didLogFirstEvent = false
+    /// Same problem one level in: events arrive, but none of them match the
+    /// configured hotkey. Log the first non-matching modifier so a wrong-key
+    /// or wrong-keycode diagnosis takes one press instead of a rebuild.
+    private var didLogFirstUnmatched = false
 
     /// User's current hotkey (set via Settings → Hotkey submenu).
     var hotkey: HotkeyChoice = hotkeyChoice(forKeycode: DEFAULT_HOTKEY_KEYCODE)
@@ -2865,11 +2875,20 @@ final class HotkeyListener {
             return false
         }
 
+        if !didLogFirstEvent {
+            didLogFirstEvent = true
+            log("HotkeyListener: first event received (type=\(event.typeRawValue) keycode=\(event.keycode)) — tap is delivering")
+        }
+
         let result = transitionState.transition(for: event,
                                                 hotkey: hotkey,
                                                 triggerMode: triggerMode,
                                                 isRecording: isRecordingActive?() ?? false,
                                                 canStartRecording: canStartRecording?() ?? true)
+        if result.actions.isEmpty, !didLogFirstUnmatched, event.keycode != hotkey.keycode {
+            didLogFirstUnmatched = true
+            log("HotkeyListener: saw keycode \(event.keycode) but watching \(hotkey.name) (keycode \(hotkey.keycode))")
+        }
         dispatchHotkeyActions(result.actions)
         return result.suppress
     }
@@ -6791,7 +6810,18 @@ final class PresspeechApp: NSObject, NSApplicationDelegate, NSWindowDelegate {
     // MARK: - Recording loop
 
     private func handlePress() {
-        guard isReady, !isRecording, !isBusy, !isTerminating else { return }
+        // This guard used to return silently, which meant a press that the app
+        // deliberately declined looked exactly like a press it never received.
+        // Name the reason — it is the difference between a permissions problem
+        // and a not-finished-loading problem.
+        guard isReady, !isRecording, !isBusy, !isTerminating else {
+            let reason = !isReady ? "not ready (ASR still loading?)"
+                : isRecording ? "already recording"
+                : isBusy ? "busy transcribing"
+                : "terminating"
+            log("press ignored: \(reason)")
+            return
+        }
         let missing = missingPermissions()
         guard missing.isEmpty else {
             enterPermissionBlockedState(missing: missing, reason: "hotkey press")

--- a/swift/dev-run.sh
+++ b/swift/dev-run.sh
@@ -78,6 +78,14 @@ say "Stopping any prior dev instance..."
 pkill -f "Presspeech-dev.app" 2>/dev/null || true
 # Also kill any Cask instance — same bundle id would clash on TCC + hotkey.
 pkill -f "/Applications/Presspeech.app" 2>/dev/null || true
+
+# pkill is a SIGTERM the app never gets to handle, so the active-run marker it
+# sets at launch is left standing and the NEXT launch shows the "Reopened After
+# an Unexpected Exit" alert — whose default button is Copy Diagnostics. That
+# notice is for real crashes; a deliberate stop by this script is not one, so
+# clear the marker rather than crying wolf on every dev iteration.
+sleep 0.5
+defaults write com.local.presspeech active_run_marker -bool false 2>/dev/null || true
 sleep 0.5
 
 say "Launching..."


### PR DESCRIPTION
Two small fixes found while debugging a "the hotkey does nothing" report on my own machine. Both are independent of each other and of anything else I'm working on.

## Report why a hotkey press produced no recording

Three layers can swallow a press, and all three were silent, so a dead event tap and an untouched keyboard produced byte-identical logs:

1. `CGEvent.tapCreate` succeeds even when Input Monitoring is stale, so `HotkeyListener: tap active` is logged and then no event ever arrives.
2. Events arrive, but none match the configured keycode.
3. `handlePress` declines via `guard isReady, !isRecording, !isBusy, !isTerminating else { return }`.

In my case it turned out to be (2) — I was pressing Left Option and Right Shift while the app watched Right Option. That took a while to establish, because the only evidence available was the *absence* of output: `tap active` is printed either way, and nothing distinguishes "the tap is dead" from "you have not pressed anything yet."

This adds three log lines:

- the first event the tap actually delivers, which proves it is live
- the first keycode that does not match the configured hotkey, with both keycodes named
- the reason a press was declined, instead of a bare `return`

With these, diagnosis took a single keypress:

```
[19:10:02] HotkeyListener: first event received (type=12 keycode=58) — tap is delivering
[19:10:02] HotkeyListener: saw keycode 58 but watching Right Option (keycode 61)
```

Both "first" lines are one-shot per launch, so this does not add per-event logging to the hot path.

## Clear the active-run marker when dev-run stops the app

`dev-run.sh` uses `pkill`, which is a SIGTERM a Cocoa app never handles, so the active-run marker set at launch is left standing. The next launch then shows the "Reopened After an Unexpected Exit" alert, whose default button is Copy Diagnostics.

That notice is for real crashes. A deliberate stop by the dev script is not one, so the script clears the marker rather than firing the alert on every iteration.

## Testing

`swift build` clean and `swift run Presspeech --self-test all` passes with both commits applied. Branched directly from `34746c6`, and touches only `main.swift` and `dev-run.sh` — no other changes mixed in.

Happy to split these into two PRs, drop either one, or adjust the log wording to match your preferences.