### PR TITLE
Keep ignored data off native QA workers

### DIFF
--- a/infra/maintainer-vm/README.md
+++ b/infra/maintainer-vm/README.md
@@ -45,10 +45,12 @@ readiness report. Do not copy the Pulse maintainer's ChatGPT refresh tokens;
 each unattended machine must have its own login state.
 
 The installer creates separate Mac and Windows QA keys and prints their public
-halves. Authorize each key only on its named worker. The QA helpers copy a clean
-working tree to a disposable directory, run the platform's native tests, and
-remove the directory afterwards. After authorizing the Windows key, prepare its
-reusable Python 3.12 environment once with:
+halves. Authorize each key only on its named worker. The QA helpers copy tracked
+files and non-ignored untracked work to a disposable directory, run the
+platform's native tests, and remove the directory afterwards. Git-ignored
+caches, logs, build products, and private benchmark recordings stay on the
+maintainer VM. After authorizing the Windows key, prepare its reusable Python
+3.12 environment once with:
 
 ```sh
 ssh presspeech-dev.local sudo -u presspeech-agent -H \

--- a/infra/maintainer-vm/bin/presspeech-mac-qa
+++ b/infra/maintainer-vm/bin/presspeech-mac-qa
@@ -20,12 +20,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
+archive_workspace() {
+  # Validate uncommitted source too, but never copy Git-ignored caches, logs,
+  # build products, or private benchmark recordings to the native worker.
+  while IFS= read -r -d '' path; do
+    if [[ -e "${workspace}/${path}" || -L "${workspace}/${path}" ]]; then
+      printf '%s\0' "${path}"
+    fi
+  done < <(git -C "${workspace}" ls-files -z --cached --others --exclude-standard) |
+    tar -C "${workspace}" --null --verbatim-files-from --files-from=- -cf -
+}
+
 ssh -o BatchMode=yes "${mac_host}" "mkdir -p -- '${remote_root}'"
-tar \
-  --exclude=.git \
-  --exclude=.build \
-  --exclude=swift/dist \
-  -C "${workspace}" -cf - . | \
+archive_workspace | \
   ssh -o BatchMode=yes "${mac_host}" "tar -C '${remote_root}' -xf -"
 
 ssh -o BatchMode=yes "${mac_host}" \

--- a/infra/maintainer-vm/bin/presspeech-windows-qa
+++ b/infra/maintainer-vm/bin/presspeech-windows-qa
@@ -26,16 +26,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
+archive_workspace() {
+  # Validate uncommitted source too, but never copy Git-ignored caches, logs,
+  # build products, or private benchmark recordings to the native worker.
+  while IFS= read -r -d '' path; do
+    if [[ -e "${workspace}/${path}" || -L "${workspace}/${path}" ]]; then
+      printf '%s\0' "${path}"
+    fi
+  done < <(git -C "${workspace}" ls-files -z --cached --others --exclude-standard) |
+    tar -C "${workspace}" --null --verbatim-files-from --files-from=- -cf -
+}
+
 ssh "${windows_host}" \
   "powershell -NoProfile -NonInteractive -Command \"New-Item -ItemType Directory -Force -Path '${remote_root}' | Out-Null\""
-tar \
-  --exclude=.git \
-  --exclude=.build \
-  --exclude=swift/dist \
-  --exclude=windows/.venv \
-  --exclude=windows/build \
-  --exclude=windows/dist \
-  -C "${workspace}" -cf - . | \
+archive_workspace | \
   ssh "${windows_host}" "tar.exe -xf - -C \"${remote_root}\""
 
 ssh "${windows_host}" \


### PR DESCRIPTION
## What changed

- build native-QA transfer archives from tracked files plus non-ignored untracked work
- omit Git-ignored caches, logs, build products, and private benchmark recordings
- document the QA handoff boundary

## Why

The QA wrappers previously archived the entire working directory with a short hard-coded exclusion list. New ignored artifact paths—and private benchmark audio already covered by repository ignore rules—could therefore be copied to native workers unnecessarily. Using Git's own ignore resolution keeps pre-commit source validation intact while making the transfer boundary follow the repository's privacy and hygiene policy.

## Validation

- patched macOS handoff: `PASS all`
- patched Windows handoff: 67 unit tests passed
- patched Windows handoff: CUDA/Parakeet end-to-end self-test passed
- archive audit: all tracked files present; zero ignored entries
- all Bash sources pass `bash -n`
- maintainer release queue self-test passed
- docs freshness and log privacy checks passed
- `git diff --check` passed
