### PR TITLE
Restore macOS hotkey recording

### DIFF
--- a/swift/Sources/Presspeech/main.swift
+++ b/swift/Sources/Presspeech/main.swift
@@ -2665,6 +2665,14 @@ private enum RecordingStartBlocker: String, Sendable {
     case terminating
 }
 
+private func resolvedRecordingStartBlocker<Owner: AnyObject>(
+    for owner: Owner?,
+    evaluate: (Owner) -> RecordingStartBlocker?
+) -> RecordingStartBlocker? {
+    guard let owner else { return .terminating }
+    return evaluate(owner)
+}
+
 private struct HotkeyTransitionResult: Equatable, Sendable {
     let suppress: Bool
     let actions: [HotkeyTransitionAction]
@@ -5921,7 +5929,9 @@ final class PresspeechApp: NSObject, NSApplicationDelegate, NSWindowDelegate {
         // Missing permissions are deliberately not a blocker here: that press
         // enters the permission-blocked state and provides its own feedback.
         hotkey.recordingStartBlocker = { [weak self] in
-            self?.recordingStartBlocker() ?? .terminating
+            resolvedRecordingStartBlocker(for: self) { app in
+                app.recordingStartBlocker()
+            }
         }
         guard hotkey.start() else {
             isReady = false
@@ -10833,6 +10843,7 @@ private enum PresspeechSelfTest {
         try testHotkeyDiagnosticModifierNames()
         try testHotkeyPreferenceUpdateResults()
         try testHotkeyRecorderRestartActions()
+        try testRecordingStartBlockerResolution()
         try testHandledHotkeySuppression()
         try testFKeyAutoRepeatSuppressesWithoutAction()
         try testRightModifierReleaseWithLeftFlagStillSet()
@@ -10997,6 +11008,29 @@ private enum PresspeechSelfTest {
             ),
             equals: .recordFailure,
             "hotkey recorder should surface restart failure after an active listener was paused"
+        )
+    }
+
+    private static func testRecordingStartBlockerResolution() throws {
+        final class Owner {}
+
+        var owner: Owner? = Owner()
+        try expect(
+            resolvedRecordingStartBlocker(for: owner) { _ in nil },
+            equals: nil,
+            "a live ready app should allow recording to start"
+        )
+        try expect(
+            resolvedRecordingStartBlocker(for: owner) { _ in .busyTranscribing },
+            equals: .busyTranscribing,
+            "a live blocked app should preserve its blocker"
+        )
+
+        owner = nil
+        try expect(
+            resolvedRecordingStartBlocker(for: owner) { _ in nil },
+            equals: .terminating,
+            "a released app should reject new recordings as terminating"
         )
     }
 

--- a/swift/release-notes/v0.3.4.md
+++ b/swift/release-notes/v0.3.4.md
@@ -1,0 +1,14 @@
+# Presspeech 0.3.4
+
+This urgent patch fixes a macOS hotkey regression introduced in 0.3.3.
+
+## Hotkey reliability
+
+- Dictation starts normally again when Presspeech is ready. Version 0.3.3
+  incorrectly treated the ready state as if the app were terminating, so every
+  hotkey press was rejected.
+- The hotkey self-test now distinguishes a ready app, a temporarily blocked
+  app, and an app that has actually terminated.
+
+There is no speech-model migration in this release. Audio and transcripts
+remain on the Mac, and transcript text never enters the diagnostic log.


### PR DESCRIPTION
## What changed

- preserve the intentional `nil` meaning “ready to record” when resolving the weak app owner
- return `.terminating` only when the app owner has actually been released
- add hotkey self-tests for ready, blocked, and released-owner states
- add focused 0.3.4 release notes

## Root cause

The 0.3.3 callback used optional chaining followed by `?? .terminating`. Because `recordingStartBlocker()` itself returns an optional, its ready-state `nil` was flattened with the weak-owner `nil`; every ready hotkey press was therefore reported as terminating.

## Impact

This restores dictation for macOS users on 0.3.3 in both hold and toggle modes.

## Validation

- `git diff --check`
- native `presspeech-mac-qa`: Swift 6 build and `Presspeech --self-test all` (`PASS all`)

Closes #17
