### PR TITLE
Update FluidAudio to v0.15.6

### DIFF
--- a/experiments/swift-bench/Package.resolved
+++ b/experiments/swift-bench/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949"
+        "revision" : "4dbf4f9f9a5ff3a53ade848d7ba4e3df13db859b"
       }
     }
   ],

--- a/experiments/swift-bench/Package.swift
+++ b/experiments/swift-bench/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/FluidInference/FluidAudio.git",
-                 revision: "19600a485baa4998812e4654b70d2bab8f2c9949"),
+                 revision: "4dbf4f9f9a5ff3a53ade848d7ba4e3df13db859b"),
     ],
     targets: [
         .executableTarget(

--- a/infra/maintainer-vm/bin/presspeech-mac-qa
+++ b/infra/maintainer-vm/bin/presspeech-mac-qa
@@ -35,5 +35,7 @@ ssh -o BatchMode=yes "${mac_host}" "mkdir -p -- '${remote_root}'"
 archive_workspace | \
   ssh -o BatchMode=yes "${mac_host}" "tar -C '${remote_root}' -xf -"
 
+# The SSH worker has no unlocked login keychain. Public SwiftPM binary
+# artifacts need no credentials, and their package checksums remain enforced.
 ssh -o BatchMode=yes "${mac_host}" \
-  "cd '${remote_root}/swift' && swift run Presspeech --self-test all"
+  "cd '${remote_root}/swift' && swift run --disable-keychain Presspeech --self-test all"

--- a/swift/Package.resolved
+++ b/swift/Package.resolved
@@ -6,7 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949"
+        "revision" : "4dbf4f9f9a5ff3a53ade848d7ba4e3df13db859b"
       }
     }
   ],

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/FluidInference/FluidAudio.git",
-                 revision: "19600a485baa4998812e4654b70d2bab8f2c9949"),
+                 revision: "4dbf4f9f9a5ff3a53ade848d7ba4e3df13db859b"),
     ],
     targets: [
         .executableTarget(

--- a/swift/release-notes/v0.3.6.md
+++ b/swift/release-notes/v0.3.6.md
@@ -1,0 +1,21 @@
+# Presspeech 0.3.6
+
+This patch updates the local speech engine with upstream correctness fixes for
+longer dictations and language hints.
+
+## Dictation reliability
+
+- Long recordings preserve token order and content more reliably where the
+  speech engine joins its 15-second processing windows.
+- Final long-form windows align to the last speech-bearing audio instead of
+  trailing silence, reducing the chance of lost content near release.
+- Language hints no longer apply an English token blocklist outside the narrow
+  French case it was designed for.
+- Transient model-download failures preserve the existing cache instead of
+  discarding usable files.
+
+The notarised app zip is now roughly 8-9 MB rather than 2.5 MB because the
+current FluidAudio package statically links additional support code. This does
+not add another speech-model download, background service, or network call.
+Audio and transcripts remain on the Mac, and transcript text never enters the
+diagnostic log.


### PR DESCRIPTION
## Summary

- update the production and benchmark FluidAudio pins to the v0.15.6 release commit
- pick up upstream long-form seam, final-window alignment, token-order, language-filter, and cache-preservation fixes
- keep noninteractive Mac QA compatible with the release checksummed public binary artifact
- add release notes that disclose the app zip growth from 2.5 MB to roughly 8-9 MB

## Verification

- presspeech-mac-qa: all Swift self-tests passed on macOS 26.5.2 / Swift 6.3.3
- clean native release build passed
- packaged-app codesign and self-test smoke passed
- 25-clip LibriSpeech dev-clean v3 regression passed
- same-Mac baseline/candidate benchmarks were transcript-identical on four generated clips; p50 deltas ranged from -3.7 ms to +0.5 ms
- 27.65-second multi-window synthetic comparison was transcript-identical (1.1% WER, final word retained); p50 159.5 ms baseline vs 163.5 ms candidate
- release-queue, release-script, benchmark-helper, docs-sync, model-manifest, and log-privacy checks passed

## Tradeoff

The release executable grows from 8,271,464 to 17,361,432 bytes, and an ad-hoc packaged zip measured 8,746,438 bytes versus the current 2,655,183-byte release asset. The model remains the dominant 500-600 MB footprint, and there is no new app runtime network call.