### PR TITLE
Read the input hardware format when installing the capture tap

### DIFF
--- a/swift/Sources/Presspeech/main.swift
+++ b/swift/Sources/Presspeech/main.swift
@@ -4462,6 +4462,18 @@ private func recordingReleaseAction(capturedSampleCount: Int,
         : .transcribe(duration: duration)
 }
 
+/// A release that captured nothing at all is not a short press — the tap ran
+/// and delivered no samples. That is precisely what a capture-format mismatch
+/// looks like from here: AVAudioEngine raises no error, the buffers are simply
+/// silent, and the clip is discarded as too short with no hint as to why. Name
+/// the likely cause instead of logging an empty clip and moving on.
+private func noAudioCapturedHint(capturedSampleCount: Int) -> String? {
+    guard capturedSampleCount == 0 else { return nil }
+    return "release: no samples captured — the input tap delivered nothing. "
+        + "Compare the \"AudioCapture: input\" rate logged above against the "
+        + "input device's actual rate; a mismatch yields silence, not an error."
+}
+
 private struct DictationTextProcessingResult: Equatable {
     let text: String
     let appliedCorrectionCount: Int
@@ -8145,6 +8157,9 @@ final class PresspeechApp: NSObject, NSApplicationDelegate, NSWindowDelegate, NS
         case .discardTooShort(let duration):
             recordingPasteTarget = nil
             dur = duration
+            if let hint = noAudioCapturedHint(capturedSampleCount: samples.count) {
+                log(hint)
+            }
             log("release: clip too short (\(String(format: "%.2f", dur)) s), discarding")
             setMenuBarState(.idle)
             rebuildMenu()
@@ -12704,6 +12719,8 @@ private enum PresspeechSelfTest {
             return runSuite("audio-route", testAudioRouteChangeDecision)
         case "recording-lifecycle":
             return runSuite("recording-lifecycle", testRecordingLifecycle)
+        case "silent-capture":
+            return runSuite("silent-capture", testSilentCaptureHint)
         case "power-state":
             return runSuite("power-state", testPowerStateRecoveryDecision)
         case "model-integrity":
@@ -12757,6 +12774,7 @@ private enum PresspeechSelfTest {
         try testSpeechModelStartupStatus()
         try testAudioRouteChangeDecision()
         try testRecordingLifecycle()
+        try testSilentCaptureHint()
         try testPowerStateRecoveryDecision()
         try testModelIntegrity()
         try testUpdate()
@@ -12765,6 +12783,18 @@ private enum PresspeechSelfTest {
         try testDiagnostics()
         try testIdentityMigration()
         try testLaunchAtLogin()
+    }
+
+    private static func testSilentCaptureHint() throws {
+        try expect(noAudioCapturedHint(capturedSampleCount: 0) != nil,
+                   equals: true,
+                   "a capture with no samples should name the format mismatch")
+        try expect(noAudioCapturedHint(capturedSampleCount: 1) == nil,
+                   equals: true,
+                   "a short but non-empty capture should not blame the format")
+        try expect(noAudioCapturedHint(capturedSampleCount: 16_000) == nil,
+                   equals: true,
+                   "a full clip should not emit the silent-capture hint")
     }
 
     private static func testLaunchAtLogin() throws {

--- a/swift/Sources/Presspeech/main.swift
+++ b/swift/Sources/Presspeech/main.swift
@@ -3622,7 +3622,15 @@ final class AudioCapture: @unchecked Sendable {
 
         let input = engine.inputNode
         applyInputDevicePreference(inputDevicePreference, to: input)
-        let inputFormat = input.outputFormat(forBus: 0)
+        // inputFormat(forBus:), not outputFormat(forBus:). The latter reports
+        // the engine graph's rate, which follows the default *output* device.
+        // applyInputDevicePreference() has just repointed the audio unit at a
+        // different input device, so the two disagree whenever output and input
+        // hardware run at different rates — a 44.1 kHz Bluetooth headset
+        // alongside a 48 kHz microphone. A tap installed against the graph rate
+        // then receives buffers of pure silence, with no error raised anywhere:
+        // the capture simply comes back empty and is discarded as too short.
+        let inputFormat = input.inputFormat(forBus: 0)
 
         guard let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,


### PR DESCRIPTION
## Summary

`AudioCapture.startEngine` took its tap format from `input.outputFormat(forBus:)`,
which reports the engine graph's rate rather than the input hardware's. The graph
follows the default **output** device, so the two agree only while output and input
happen to run at the same rate. `applyInputDevicePreference` has already repointed
the audio unit at the chosen input by that line, so once a 44.1 kHz Bluetooth
headset became the default output alongside a 48 kHz microphone, the tap was
installed against 44100 while the device produced 48000.

CoreAudio raises nothing in that case. The tap simply delivers silent buffers, so
every capture came back at `rms 0.0000` and was discarded as too short, while the
log still named the correct input device. Reading `inputFormat(forBus:)` describes
the hardware actually feeding the tap and leaves the converter to resample to the
16 kHz target exactly as before.

The second commit addresses why this took so long to identify. A format mismatch
is indistinguishable from a mis-timed key press in the log — a zero-length clip
and nothing else. A capture that produced no samples whatsoever is now
distinguished from one that was merely brief, and points at the rate comparison
that identifies it.

Two alternatives were tried and rejected. `installTap(format: nil)` fails engine
startup outright with `-10868 kAudioUnitErr_FormatNotSupported`. Rebuilding the
converter inside `handleTap` when the delivered format disagrees works, but
allocates an `AVAudioConverter` on the audio thread, which contradicts the
render-thread discipline documented on the class.

## Verification

Mac16,10 (Apple M4), macOS 26.6.2, Blue Yeti Nano + Bose QuietComfort Headphones
(A2DP, locked to 44.1 kHz).

`--self-test all` passes, including the new `silent-capture` suite.
`scripts/check-log-privacy.py` passes. Release build compiles with no new warnings.

End-to-end dictation, real audio through the full capture path:

| input rate | output rate | before | after |
|---|---|---|---|
| 48000 (Yeti) | 44100 (Bose) | `rms 0.0000`, discarded | captured, transcribed |
| 44100 (Yeti) | 44100 (Bose) | captured | captured, transcribed |
| 44100 (Yeti) | 48000 (USB DAC) | not tested | captured, transcribed |
| 16000 mono (Bose HFP) | 44100 | not tested | engine starts, correct rate |

The diagnostic was verified by temporarily reintroducing the bug and confirming
the new line fires in the real failure mode, then reverting.

**Verification gap:** the 16 kHz Bluetooth-microphone row was confirmed only as
far as engine startup reporting the correct format. No capture was recorded
through that path.

## Checklist

- [x] The change stays local-only and adds no telemetry, analytics, accounts,
      cloud transcription, or undocumented network calls.
- [x] Transcript content is never written to logs. The added line reports sample
      counts only; `check-log-privacy.py` passes.
- [x] macOS changes preserve the Swift concurrency, audio-converter, TCC,
      entitlements, and resource-bundling invariants documented in `AGENTS.md`.
      Nothing was added to the render thread and `AudioCapture` remains
      `@unchecked Sendable` with its existing `NSLock` discipline.
- [x] No Windows changes.
- [x] Relevant self-tests and native QA have passed, with the one verification
      gap noted above.
- [x] No user-facing behavior or privacy documentation changes are needed; this
      restores intended behavior and adds a log line only.
